### PR TITLE
 Remove definitions of stl containers with incomplete types

### DIFF
--- a/orocos_kdl/CMakeLists.txt
+++ b/orocos_kdl/CMakeLists.txt
@@ -13,13 +13,12 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 
 PROJECT(orocos_kdl)
 
-SET( KDL_VERSION 1.2.3 CACHE STRING "Version of Orocos KDL" )
+SET( KDL_VERSION 1.2.3)
 STRING( REGEX MATCHALL "[0-9]+" KDL_VERSIONS ${KDL_VERSION} )
 LIST( GET KDL_VERSIONS 0 KDL_VERSION_MAJOR)
 LIST( GET KDL_VERSIONS 1 KDL_VERSION_MINOR)
 LIST( GET KDL_VERSIONS 2 KDL_VERSION_PATCH)
 
-SET(KDL_VERSION_PATCH "${KDL_VERSION_PATCH}")
 MESSAGE( "Orocos KDL version ${VERSION} (${KDL_VERSION_MAJOR}.${KDL_VERSION_MINOR}.${KDL_VERSION_PATCH})" )
 
 SET( PROJ_SOURCE_DIR ${orocos_kdl_SOURCE_DIR} )
@@ -50,6 +49,27 @@ if(NOT Eigen_FOUND)
 endif()
 include_directories(${Eigen_INCLUDE_DIR})
 SET(KDL_CFLAGS "${KDL_CFLAGS} -I${Eigen_INCLUDE_DIR}")
+
+# Check the platform STL containers capabilities
+include(config/CheckSTLContainers.cmake)
+CHECK_STL_CONTAINERS()
+
+# Set the default option appropriately
+if(HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+    set(KDL_USE_NEW_TREE_INTERFACE_DEFAULT Off)
+else(HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+    set(KDL_USE_NEW_TREE_INTERFACE_DEFAULT On)
+endif(HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+
+# Allow the user to select the Tree API version to use
+set(KDL_USE_NEW_TREE_INTERFACE ${KDL_USE_NEW_TREE_INTERFACE_DEFAULT} CACHE BOOL "Use the new KDL Tree interface")
+
+# The new interface requires the use of shared pointers
+if(KDL_USE_NEW_TREE_INTERFACE)
+    # We need shared_ptr from boost since not all compilers are c++11 capable
+    find_package(Boost REQUIRED)
+    include_directories(${Boost_INCLUDE_DIRS})
+endif(KDL_USE_NEW_TREE_INTERFACE)
 
 INCLUDE (${PROJ_SOURCE_DIR}/config/DependentOption.cmake)
 

--- a/orocos_kdl/config/CheckSTLContainers.cmake
+++ b/orocos_kdl/config/CheckSTLContainers.cmake
@@ -1,0 +1,47 @@
+# - Macro to check whether the STL containers support incomplete types
+# The issue at stake is discussed here in depth:
+# http://www.drdobbs.com/the-standard-librarian-containers-of-inc/184403814
+#
+# Empirically libstdc++ and MSVC++ support containers of incomplete types
+# whereas libc++ does not.
+#
+# The result is returned in HAVE_STL_CONTAINER_INCOMPLETE_TYPES
+#
+# Copyright 2014 Brian Jensen <Jensen dot J dot Brian at gmail dot com>
+# Author: Brian Jensen <Jensen dot J dot Brian at gmail dot com>
+#
+
+macro(CHECK_STL_CONTAINERS)
+    INCLUDE(CheckCXXSourceCompiles)
+    SET(CMAKE_REQUIRED_FLAGS)
+    CHECK_CXX_SOURCE_COMPILES("
+        #include <string>
+        #include <map>
+        #include <vector>
+
+        class TreeElement;
+        typedef std::map<std::string, TreeElement> SegmentMap;
+
+        class TreeElement
+        {
+            TreeElement(const std::string& name): number(0) {}
+
+        public:
+            int number;
+            SegmentMap::const_iterator parent;
+            std::vector<SegmentMap::const_iterator> children;
+
+            static TreeElement Root(std::string& name)
+            {
+                return TreeElement(name);
+            }
+        };
+
+        int main()
+        {
+            return 0;
+        }
+        "
+        HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+
+endmacro(CHECK_STL_CONTAINERS)

--- a/orocos_kdl/src/CMakeLists.txt
+++ b/orocos_kdl/src/CMakeLists.txt
@@ -3,6 +3,52 @@ FILE( GLOB KDL_HPPS [^.]*.hpp [^.]*.inl)
 
 FILE( GLOB UTIL_HPPS utilities/[^.]*.h utilities/[^.]*.hpp)
 
+INCLUDE(CheckCXXSourceCompiles)
+SET(CMAKE_REQUIRED_FLAGS)
+CHECK_CXX_SOURCE_COMPILES("
+    #include <string>
+    #include <map>
+    #include <vector.hpp>
+
+    class TreeElement;
+    typedef std::map<std::string, TreeElement> SegmentMap;
+
+    class TreeElement
+    {
+        TreeElement(const std::string& name): number(0) {}
+
+    public:
+        int number;
+        SegmentMap::const_iterator parent;
+        std::vector<SegmentMap::const_iterator> children;
+
+        static TreeElement Root(std::string& name)
+        {
+            return TreeElement(name);
+        }
+    };
+
+    int main()
+    {
+        return 0;
+    }
+    "
+    HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+
+if(HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+    SET(KDL_USE_NEW_TREE_INTERFACE_DEFAULT Off)
+ELSE(HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+    SET(KDL_USE_NEW_TREE_INTERFACE_DEFAULT On)
+ENDIF(HAVE_STL_CONTAINER_INCOMPLETE_TYPES)
+
+SET(KDL_USE_NEW_TREE_INTERFACE ${KDL_USE_NEW_TREE_INTERFACE_DEFAULT} CACHE BOOL "Use the new KDL Tree interface")
+
+#Sanity check, inform the user
+IF(NOT HAVE_STL_CONTAINER_INCOMPLETE_TYPES AND NOT KDL_USE_NEW_TREE_INTERFACE)
+    MESSAGE(WARNING "You have chosen to use the current Tree Interface, but your platform doesn't support containers of "
+        "incomplete types, this configuration is likely invalid")
+ENDIF()
+
 #In Windows (Visual Studio) it is necessary to specify the postfix
 #of the debug library name and no symbols are exported by kdl, 
 #so it is necessary to compile it as a static library
@@ -13,15 +59,21 @@ ELSE(MSVC)
     SET(LIB_TYPE SHARED)
 ENDIF(MSVC)
 
-ADD_LIBRARY(orocos-kdl ${LIB_TYPE} ${KDL_SRCS})
+CONFIGURE_FILE(config.h.in config.h @ONLY)
+
+ADD_LIBRARY(orocos-kdl ${LIB_TYPE} ${KDL_SRCS} config.h.in)
  
 SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
   SOVERSION "${KDL_VERSION_MAJOR}.${KDL_VERSION_MINOR}"
   VERSION "${KDL_VERSION}"
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS}"
   INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib"
-  PUBLIC_HEADER "${KDL_HPPS}"
+  PUBLIC_HEADER "${KDL_HPPS};${CMAKE_CURRENT_BINARY_DIR}/config.h"
   )
+
+# Needed so that the generated config.h can be used
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})
+TARGET_LINK_LIBRARIES(orocos-kdl ${Boost_LIBRARIES})
 
 INSTALL(TARGETS orocos-kdl
   EXPORT OrocosKDLTargets

--- a/orocos_kdl/src/config.h.in
+++ b/orocos_kdl/src/config.h.in
@@ -1,0 +1,37 @@
+// Copyright  (C)  2014  Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+
+// Version: 1.0
+// Author: Brian Jensen <Jensen dot J dot Brian at gmail dot com>
+// Maintainer: Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef KDL_CONFIG_H
+#define KDL_CONFIG_H
+
+#define KDL_VERSION_MAJOR @KDL_VERSION_MAJOR@
+#define KDL_VERSION_MINOR @KDL_VERSION_MINOR@
+#define KDL_VERSION_PATCH @KDL_VERSION_PATCH@
+
+#define KDL_VERSION (KDL_VERSION_MAJOR << 16) | (KDL_VERSION_MINOR << 8) | KDL_VERSION_PATCH
+
+#define KDL_VERSION_STRING "@KDL_VERSION@"
+
+//Set which version of the Tree Interface to use
+#cmakedefine HAVE_STL_CONTAINER_INCOMPLETE_TYPES
+#cmakedefine KDL_USE_NEW_TREE_INTERFACE
+
+#endif //#define KDL_CONFIG_H

--- a/orocos_kdl/src/kinfam_io.cpp
+++ b/orocos_kdl/src/kinfam_io.cpp
@@ -60,9 +60,9 @@ std::ostream& operator <<(std::ostream& os, const Tree& tree) {
 
 std::ostream& operator <<(std::ostream& os, SegmentMap::const_iterator root) {
 	//os<<root->first<<": "<<root->second.segment<<"\n";
-	os << root->first<<"(q_nr: "<<root->second.q_nr<<")"<<"\n \t";
-	for (unsigned int i = 0; i < root->second.children.size(); i++) {
-		os <<(root->second.children[i])<<"\t";
+    os << root->first<<"(q_nr: "<< GetTreeElementQNr(root->second) << ")" << "\n \t";
+    for (unsigned int i = 0; i < GetTreeElementChildren(root->second).size(); i++) {
+        os << ( GetTreeElementChildren(root->second)[i] ) << "\t";
 	}
 	return os << "\n";
 }

--- a/orocos_kdl/src/tree.cpp
+++ b/orocos_kdl/src/tree.cpp
@@ -37,7 +37,7 @@ Tree::Tree(const Tree& in) {
     root_name = in.root_name;
 
     segments.insert(make_pair(root_name, TreeElement::Root(root_name)));
-    this->addTree(in, root_name);
+    addTree(in, root_name);
 }
 
 Tree& Tree::operator=(const Tree& in) {
@@ -59,12 +59,18 @@ bool Tree::addSegment(const Segment& segment, const std::string& hook_name) {
     pair<SegmentMap::iterator, bool> retval;
     //insert new element
     unsigned int q_nr = segment.getJoint().getType() != Joint::None ? nrOfJoints : 0;
-    retval = segments.insert(make_pair(segment.getName(), TreeElement(segment, parent, q_nr)));
+
+#ifdef KDL_USE_NEW_TREE_INTERFACE
+    retval = segments.insert(make_pair(segment.getName(), TreeElementType( new TreeElement(segment, parent, q_nr))));
+#else //#ifdef KDL_USE_NEW_TREE_INTERFACE
+    retval = segments.insert(make_pair(segment.getName(), TreeElementType(segment, parent, q_nr)));
+#endif //#ifdef KDL_USE_NEW_TREE_INTERFACE
+
     //check if insertion succeeded
     if (!retval.second)
         return false;
     //add iterator to new element in parents children list
-    parent->second.children.push_back(retval.first);
+    GetTreeElementChildren(parent->second).push_back(retval.first);
     //increase number of segments
     nrOfSegments++;
     //increase number of joints
@@ -92,10 +98,10 @@ bool Tree::addTreeRecursive(SegmentMap::const_iterator root, const std::string& 
     //get iterator for root-segment
     SegmentMap::const_iterator child;
     //try to add all of root's children
-    for (unsigned int i = 0; i < root->second.children.size(); i++) {
-        child = root->second.children[i];
+    for (unsigned int i = 0; i < GetTreeElementChildren(root->second).size(); i++) {
+        child = GetTreeElementChildren(root->second)[i];
         //Try to add the child
-        if (this->addSegment(child->second.segment, hook_name)) {
+        if (this->addSegment(GetTreeElementSegment(child->second), hook_name)) {
             //if child is added, add all the child's children
             if (!(this->addTreeRecursive(child, child->first)))
                 //if it didn't work, return false
@@ -114,12 +120,12 @@ bool Tree::addTreeRecursive(SegmentMap::const_iterator root, const std::string& 
         
         // walk down from chain_root and chain_tip to the root of the tree
         vector<SegmentMap::key_type> parents_chain_root, parents_chain_tip;
-        for (SegmentMap::const_iterator s=getSegment(chain_root); s!=segments.end(); s=s->second.parent){
+        for (SegmentMap::const_iterator s=getSegment(chain_root); s!=segments.end(); s = GetTreeElementParent(s->second)){
             parents_chain_root.push_back(s->first);
             if (s->first == root_name) break;
         }
         if (parents_chain_root.empty() || parents_chain_root.back() != root_name) return false;
-        for (SegmentMap::const_iterator s=getSegment(chain_tip); s!=segments.end(); s=s->second.parent){
+        for (SegmentMap::const_iterator s=getSegment(chain_tip); s!=segments.end(); s = GetTreeElementParent(s->second)){
             parents_chain_tip.push_back(s->first);
             if (s->first == root_name) break;
         }
@@ -138,20 +144,20 @@ bool Tree::addTreeRecursive(SegmentMap::const_iterator root, const std::string& 
         
         // add the segments from the root to the common frame
         for (unsigned int s=0; s<parents_chain_root.size()-1; s++){
-            Segment seg = getSegment(parents_chain_root[s])->second.segment;
+            Segment seg = GetTreeElementSegment(getSegment(parents_chain_root[s])->second);
             Frame f_tip = seg.pose(0.0).Inverse();
             Joint jnt = seg.getJoint();
             if (jnt.getType() == Joint::RotX || jnt.getType() == Joint::RotY || jnt.getType() == Joint::RotZ || jnt.getType() == Joint::RotAxis)
 	      jnt = Joint(jnt.getName(), f_tip*jnt.JointOrigin(), f_tip.M*(-jnt.JointAxis()), Joint::RotAxis);
 	    else if (jnt.getType() == Joint::TransX || jnt.getType() == Joint::TransY || jnt.getType() == Joint::TransZ || jnt.getType() == Joint::TransAxis)
 	      jnt = Joint(jnt.getName(),f_tip*jnt.JointOrigin(), f_tip.M*(-jnt.JointAxis()), Joint::TransAxis);
-	    chain.addSegment(Segment(getSegment(parents_chain_root[s+1])->second.segment.getName(),
-                                     jnt, f_tip, getSegment(parents_chain_root[s+1])->second.segment.getInertia()));
+        chain.addSegment(Segment(GetTreeElementSegment(getSegment(parents_chain_root[s+1])->second).getName(),
+                                     jnt, f_tip, GetTreeElementSegment(getSegment(parents_chain_root[s+1])->second).getInertia()));
         }
         
         // add the segments from the common frame to the tip frame
         for (int s=parents_chain_tip.size()-1; s>-1; s--){
-            chain.addSegment(getSegment(parents_chain_tip[s])->second.segment);
+            chain.addSegment(GetTreeElementSegment(getSegment(parents_chain_tip[s])->second));
         }
         return true;
     }

--- a/orocos_kdl/src/tree.hpp
+++ b/orocos_kdl/src/tree.hpp
@@ -22,38 +22,72 @@
 #ifndef KDL_TREE_HPP
 #define KDL_TREE_HPP
 
+#include "config.h"
+
 #include "segment.hpp"
 #include "chain.hpp"
 
 #include <string>
 #include <map>
 
+#ifdef KDL_USE_NEW_TREE_INTERFACE
+#include <boost/shared_ptr.hpp>
+#endif //#ifdef KDL_USE_NEW_TREE_INTERFACE
+
 namespace KDL
 {
-    //Forward declaration
     class TreeElement;
+
+#ifdef KDL_USE_NEW_TREE_INTERFACE
+    //We use smart pointers for managing tree nodes for now becuase
+    //c++11 and unique_ptr support is not ubiquitous
+    typedef boost::shared_ptr<TreeElement> TreeElementPtr;
+    typedef boost::shared_ptr<const TreeElement> TreeElementConstPtr;
+    typedef std::map<std::string, TreeElementPtr> SegmentMap;
+    typedef TreeElementPtr TreeElementType;
+
+#define GetTreeElementChildren(tree_element) (tree_element)->children
+#define GetTreeElementParent(tree_element) (tree_element)->parent
+#define GetTreeElementQNr(tree_element) (tree_element)->q_nr
+#define GetTreeElementSegment(tree_element) (tree_element)->segment
+
+#else //#ifdef KDL_USE_NEW_TREE_INTERFACE
+    //Forward declaration
     typedef std::map<std::string,TreeElement> SegmentMap;
+    typedef TreeElement TreeElementType;
+
+#define GetTreeElementChildren(tree_element) (tree_element).children
+#define GetTreeElementParent(tree_element) (tree_element).parent
+#define GetTreeElementQNr(tree_element) (tree_element).q_nr
+#define GetTreeElementSegment(tree_element) (tree_element).segment
+
+#endif //#ifdef KDL_USE_NEW_TREE_INTERFACE
 
     class TreeElement
     {
-    private:
-        TreeElement(const std::string& name):segment(name), q_nr(0)
-        {};
     public:
+        TreeElement(const Segment& segment_in,const SegmentMap::const_iterator& parent_in,unsigned int q_nr_in):
+            segment(segment_in),
+            q_nr(q_nr_in),
+            parent(parent_in)
+        {}
+
+        static TreeElementType Root(const std::string& root_name)
+        {
+#ifdef KDL_USE_NEW_TREE_INTERFACE
+            return TreeElementType(new TreeElement(root_name));
+#else //#define KDL_USE_NEW_TREE_INTERFACE
+            return TreeElementType(root_name);
+#endif
+        }
+
         Segment segment;
         unsigned int q_nr;
         SegmentMap::const_iterator  parent;
         std::vector<SegmentMap::const_iterator > children;
-        TreeElement(const Segment& segment_in,const SegmentMap::const_iterator& parent_in,unsigned int q_nr_in)
-        {
-			q_nr=q_nr_in;
-            segment=segment_in;
-            parent=parent_in;
-        };
-        static TreeElement Root(const std::string& root_name)
-        {
-            return TreeElement(root_name);
-        };
+
+    private:
+        TreeElement(const std::string& name):segment(name), q_nr(0) {}
     };
 
     /**

--- a/orocos_kdl/src/treefksolverpos_recursive.cpp
+++ b/orocos_kdl/src/treefksolverpos_recursive.cpp
@@ -40,8 +40,7 @@ namespace KDL {
         else if(it == tree.getSegments().end()) //if the segment name is not found
          	return -2;
         else{
-        	const TreeElement& currentElement = it->second;
-			p_out = recursiveFk(q_in, it);	
+			p_out = recursiveFk(q_in, it);
         	return 0;        	
         }
     }
@@ -49,15 +48,15 @@ namespace KDL {
 	Frame TreeFkSolverPos_recursive::recursiveFk(const JntArray& q_in, const SegmentMap::const_iterator& it)
 	{
 		//gets the frame for the current element (segment)
-		const TreeElement& currentElement = it->second;
-		Frame currentFrame = currentElement.segment.pose(q_in(currentElement.q_nr));
-		
+        const TreeElementType& currentElement = it->second;
+        Frame currentFrame = GetTreeElementSegment(currentElement).pose(q_in(GetTreeElementQNr(currentElement)));
+
 		SegmentMap::const_iterator rootIterator = tree.getRootSegment();
 		if(it == rootIterator){
 			return currentFrame;	
 		}
 		else{
-			SegmentMap::const_iterator parentIt = currentElement.parent;
+            SegmentMap::const_iterator parentIt = GetTreeElementParent(currentElement);
 			return recursiveFk(q_in, parentIt) * currentFrame;
 		}
 	}

--- a/orocos_kdl/src/treejnttojacsolver.cpp
+++ b/orocos_kdl/src/treejnttojacsolver.cpp
@@ -39,16 +39,16 @@ int TreeJntToJacSolver::JntToJac(const JntArray& q_in, Jacobian& jac, const std:
     //Lets recursively iterate until we are in the root segment
     while (it != root) {
         //get the corresponding q_nr for this TreeElement:
-        unsigned int q_nr = it->second.q_nr;
+        unsigned int q_nr = GetTreeElementQNr(it->second);
         
         //get the pose of the segment:
-        Frame T_local = it->second.segment.pose(q_in(q_nr));
+        Frame T_local = GetTreeElementSegment(it->second).pose(q_in(q_nr));
         //calculate new T_end:
         T_total = T_local * T_total;
         
         //get the twist of the segment:
-        if (it->second.segment.getJoint().getType() != Joint::None) {
-            Twist t_local = it->second.segment.twist(q_in(q_nr), 1.0);
+        if (GetTreeElementSegment(it->second).getJoint().getType() != Joint::None) {
+            Twist t_local = GetTreeElementSegment(it->second).twist(q_in(q_nr), 1.0);
             //transform the endpoint of the local twist to the global endpoint:
             t_local = t_local.RefPoint(T_total.p - T_local.p);
             //transform the base of the twist to the endpoint
@@ -57,7 +57,7 @@ int TreeJntToJacSolver::JntToJac(const JntArray& q_in, Jacobian& jac, const std:
             jac.setColumn(q_nr,t_local);
         }//endif
         //goto the parent
-        it = it->second.parent;
+        it = GetTreeElementParent(it->second);
     }//endwhile
     //Change the base of the complete jacobian from the endpoint to the base
     changeBase(jac, T_total.M, jac);


### PR DESCRIPTION
This a fix primarily targeting OS X 10.9 Mavericks with clang/libc++, but in principle the issue likely affects any non libstc++ based toolchain. In essence the problem was that an stl container (`map`) was defined to contain complete instances (not pointers) of the `TreeElement`class, before this class was fully defined by means of a forward declaration. This behaviour is forbidden by the c++ standard and clang/libc++ rightly refuses to compile this construct. I changed to code to use boost smart pointers instead, while at the same time trying to implement the original semantics of the original illegal code (i.e. copy by value instead by reference). 

This change fixes the relevant issues mentioned here: http://answers.ros.org/question/94771/building-octomap-orocos_kdl-and-other-packages-on-osx-109-solution/
