### PR TITLE
Add url to ROS wiki in package.xml

### DIFF
--- a/orocos_kdl/package.xml
+++ b/orocos_kdl/package.xml
@@ -6,6 +6,7 @@
     Library (KDL), distributed by the Orocos Project. 
   </description>
   <maintainer email="ruben@intermodalics.eu">Ruben Smits</maintainer>
+  <url>http://wiki.ros.org/orocos_kdl</url>
   <license>LGPL</license>
 
   <buildtool_depend>cmake</buildtool_depend>

--- a/python_orocos_kdl/package.xml
+++ b/python_orocos_kdl/package.xml
@@ -6,6 +6,7 @@
     Library (KDL), distributed by the Orocos Project. 
   </description>
   <maintainer email="ruben@intermodalics.eu">Ruben Smits</maintainer>
+  <url>http://wiki.ros.org/python_orocos_kdl</url>
   <license>LGPL</license>
 
   <buildtool_depend>cmake</buildtool_depend>


### PR DESCRIPTION
I'm using a script which requires package.xml files have url elements. I added some pointing to the ROS wiki.
