### PR TITLE
CMake config file fixes

### DIFF
--- a/orocos_kdl/KDLConfig.cmake.in
+++ b/orocos_kdl/KDLConfig.cmake.in
@@ -2,6 +2,7 @@
 # It defines the following variables
 #  orocos_kdl_INCLUDE_DIRS - include directories for Orocos KDL
 #  orocos_kdl_LIBRARIES    - libraries to link against for Orocos KDL
+#  orocos_kdl_PKGCONFIG_DIR - directory containing the .pc pkgconfig files
 
 # Compute paths
 get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
@@ -12,3 +13,6 @@ if(NOT TARGET orocos-kdl)
 endif()
 
 set(orocos_kdl_LIBRARIES orocos-kdl)
+
+# where the .pc pkgconfig files are installed
+set(orocos_kdl_PKGCONFIG_DIR "@CMAKE_INSTALL_PREFIX@/lib/pkgconfig")


### PR DESCRIPTION
Fix typo's, and store the pkgconfig output dir (for use by dependent packages)
