### PR TITLE
Correct friend function declarations with default arguments

### DIFF
--- a/orocos_kdl/src/frameacc.hpp
+++ b/orocos_kdl/src/frameacc.hpp
@@ -40,6 +40,23 @@ namespace KDL {
 class TwistAcc;
 typedef Rall2d<double,double,double> doubleAcc;
 
+// Equal is friend function, but default arguments for friends are forbidden (§8.3.6.4)
+class FrameAcc;
+class RotationAcc;
+class VectorAcc;
+
+IMETHOD bool Equal(const FrameAcc& r1,const FrameAcc& r2,double eps=epsilon);
+IMETHOD bool Equal(const Frame& r1,const FrameAcc& r2,double eps=epsilon);
+IMETHOD bool Equal(const FrameAcc& r1,const Frame& r2,double eps=epsilon);
+IMETHOD bool Equal(const RotationAcc& r1,const RotationAcc& r2,double eps=epsilon);
+IMETHOD bool Equal(const Rotation& r1,const RotationAcc& r2,double eps=epsilon);
+IMETHOD bool Equal(const RotationAcc& r1,const Rotation& r2,double eps=epsilon);
+IMETHOD bool Equal(const TwistAcc& a,const TwistAcc& b,double eps=epsilon);
+IMETHOD bool Equal(const Twist& a,const TwistAcc& b,double eps=epsilon);
+IMETHOD bool Equal(const TwistAcc& a,const Twist& b,double eps=epsilon);
+IMETHOD bool Equal(const VectorAcc& r1,const VectorAcc& r2,double eps=epsilon);
+IMETHOD bool Equal(const Vector& r1,const VectorAcc& r2,double eps=epsilon);
+IMETHOD bool Equal(const VectorAcc& r1,const Vector& r2,double eps=epsilon);
 
 class VectorAcc
 {
@@ -79,9 +96,9 @@ public:
     IMETHOD friend VectorAcc operator / (const VectorAcc& r2,const doubleAcc& r1);
 
 
-    IMETHOD friend bool Equal(const VectorAcc& r1,const VectorAcc& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const Vector& r1,const VectorAcc& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const VectorAcc& r1,const Vector& r2,double eps=epsilon);
+    IMETHOD friend bool Equal(const VectorAcc& r1,const VectorAcc& r2,double eps);
+    IMETHOD friend bool Equal(const Vector& r1,const VectorAcc& r2,double eps);
+    IMETHOD friend bool Equal(const VectorAcc& r1,const Vector& r2,double eps);
     IMETHOD friend VectorAcc operator - (const VectorAcc& r);
     IMETHOD friend doubleAcc dot(const VectorAcc& lhs,const VectorAcc& rhs);
     IMETHOD friend doubleAcc dot(const VectorAcc& lhs,const Vector& rhs);
@@ -133,9 +150,9 @@ public:
     IMETHOD friend RotationAcc operator* (const RotationAcc& r1,const RotationAcc& r2);
     IMETHOD friend RotationAcc operator* (const Rotation& r1,const RotationAcc& r2);
     IMETHOD friend RotationAcc operator* (const RotationAcc& r1,const Rotation& r2);
-    IMETHOD friend bool Equal(const RotationAcc& r1,const RotationAcc& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const Rotation& r1,const RotationAcc& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const RotationAcc& r1,const Rotation& r2,double eps=epsilon);
+    IMETHOD friend bool Equal(const RotationAcc& r1,const RotationAcc& r2,double eps);
+    IMETHOD friend bool Equal(const Rotation& r1,const RotationAcc& r2,double eps);
+    IMETHOD friend bool Equal(const RotationAcc& r1,const Rotation& r2,double eps);
     IMETHOD TwistAcc Inverse(const TwistAcc& arg) const;
     IMETHOD TwistAcc Inverse(const Twist& arg) const;
     IMETHOD TwistAcc operator * (const TwistAcc& arg) const;
@@ -171,9 +188,9 @@ public:
     IMETHOD friend FrameAcc operator * (const FrameAcc& f1,const FrameAcc& f2);
     IMETHOD friend FrameAcc operator * (const Frame& f1,const FrameAcc& f2);
     IMETHOD friend FrameAcc operator * (const FrameAcc& f1,const Frame& f2);
-    IMETHOD friend bool Equal(const FrameAcc& r1,const FrameAcc& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const Frame& r1,const FrameAcc& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const FrameAcc& r1,const Frame& r2,double eps=epsilon);
+    IMETHOD friend bool Equal(const FrameAcc& r1,const FrameAcc& r2,double eps);
+    IMETHOD friend bool Equal(const Frame& r1,const FrameAcc& r2,double eps);
+    IMETHOD friend bool Equal(const FrameAcc& r1,const Frame& r2,double eps);
 
     IMETHOD TwistAcc  Inverse(const TwistAcc& arg) const;
     IMETHOD TwistAcc  Inverse(const Twist& arg) const;
@@ -227,9 +244,9 @@ public:
      // the new point.
      // Complexity : 6M+6A
 
-     IMETHOD friend bool Equal(const TwistAcc& a,const TwistAcc& b,double eps=epsilon);
-     IMETHOD friend bool Equal(const Twist& a,const TwistAcc& b,double eps=epsilon);
-     IMETHOD friend bool Equal(const TwistAcc& a,const Twist& b,double eps=epsilon);
+     IMETHOD friend bool Equal(const TwistAcc& a,const TwistAcc& b,double eps);
+     IMETHOD friend bool Equal(const Twist& a,const TwistAcc& b,double eps);
+     IMETHOD friend bool Equal(const TwistAcc& a,const Twist& b,double eps);
 
 
      IMETHOD Twist GetTwist() const;

--- a/orocos_kdl/src/frames.hpp
+++ b/orocos_kdl/src/frames.hpp
@@ -144,6 +144,15 @@ class Rotation2;
 class Frame2;
 
 
+// Equal is friend function, but default arguments for friends are forbidden (§8.3.6.4)
+inline bool Equal(const Vector& a,const Vector& b,double eps=epsilon);
+inline bool Equal(const Frame& a,const Frame& b,double eps=epsilon);
+inline bool Equal(const Twist& a,const Twist& b,double eps=epsilon);
+inline bool Equal(const Wrench& a,const Wrench& b,double eps=epsilon);
+inline bool Equal(const Vector2& a,const Vector2& b,double eps=epsilon);
+inline bool Equal(const Rotation2& a,const Rotation2& b,double eps=epsilon);
+inline bool Equal(const Frame2& a,const Frame2& b,double eps=epsilon);
+
 
 /**
  * \brief A concrete implementation of a 3 dimensional vector class
@@ -244,7 +253,7 @@ public:
 
      //! do not use operator == because the definition of Equal(.,.) is slightly
      //! different.  It compares whether the 2 arguments are equal in an eps-interval
-     inline friend bool Equal(const Vector& a,const Vector& b,double eps=epsilon);
+     inline friend bool Equal(const Vector& a,const Vector& b,double eps);
 
 	 //! The literal equality operator==(), also identical.
      inline friend bool operator==(const Vector& a,const Vector& b);
@@ -694,7 +703,7 @@ public:
 
      //! do not use operator == because the definition of Equal(.,.) is slightly
      //! different.  It compares whether the 2 arguments are equal in an eps-interval
-     inline friend bool Equal(const Frame& a,const Frame& b,double eps=epsilon);
+     inline friend bool Equal(const Frame& a,const Frame& b,double eps);
 
 	 //! The literal equality operator==(), also identical.
      inline friend bool operator==(const Frame& a,const Frame& b);
@@ -769,7 +778,7 @@ public:
 
      //! do not use operator == because the definition of Equal(.,.) is slightly
      //! different.  It compares whether the 2 arguments are equal in an eps-interval
-     inline friend bool Equal(const Twist& a,const Twist& b,double eps=epsilon);
+     inline friend bool Equal(const Twist& a,const Twist& b,double eps);
 
 	 //! The literal equality operator==(), also identical.
      inline friend bool operator==(const Twist& a,const Twist& b);
@@ -932,7 +941,7 @@ public:
 
      //! do not use operator == because the definition of Equal(.,.) is slightly
      //! different.  It compares whether the 2 arguments are equal in an eps-interval
-     inline friend bool Equal(const Wrench& a,const Wrench& b,double eps=epsilon);
+     inline friend bool Equal(const Wrench& a,const Wrench& b,double eps);
 
 	 //! The literal equality operator==(), also identical.
      inline friend bool operator==(const Wrench& a,const Wrench& b);
@@ -1025,7 +1034,7 @@ public:
 
      //! do not use operator == because the definition of Equal(.,.) is slightly
      //! different.  It compares whether the 2 arguments are equal in an eps-interval
-     inline friend bool Equal(const Vector2& a,const Vector2& b,double eps=epsilon);
+     inline friend bool Equal(const Vector2& a,const Vector2& b,double eps);
 
 	//! The literal equality operator==(), also identical.
 	inline friend bool operator==(const Vector2& a,const Vector2& b);
@@ -1077,7 +1086,7 @@ public:
 
      //! do not use operator == because the definition of Equal(.,.) is slightly
      //! different.  It compares whether the 2 arguments are equal in an eps-interval
-     inline friend bool Equal(const Rotation2& a,const Rotation2& b,double eps=epsilon);
+     inline friend bool Equal(const Rotation2& a,const Rotation2& b,double eps);
 };
 
 //! A 2D frame class, for further documentation see the Frames class
@@ -1118,7 +1127,7 @@ public:
         tmp.SetIdentity();
         return tmp;
      }
-     inline friend bool Equal(const Frame2& a,const Frame2& b,double eps=epsilon);
+     inline friend bool Equal(const Frame2& a,const Frame2& b,double eps);
 };
 
 /**

--- a/orocos_kdl/src/framevel.hpp
+++ b/orocos_kdl/src/framevel.hpp
@@ -67,6 +67,20 @@ class VectorVel;
 class FrameVel;
 class RotationVel;
 
+// Equal is friend function, but default arguments for friends are forbidden (§8.3.6.4)
+IMETHOD bool Equal(const VectorVel& r1,const VectorVel& r2,double eps=epsilon);
+IMETHOD bool Equal(const Vector& r1,const VectorVel& r2,double eps=epsilon);
+IMETHOD bool Equal(const VectorVel& r1,const Vector& r2,double eps=epsilon);
+IMETHOD bool Equal(const RotationVel& r1,const RotationVel& r2,double eps=epsilon);
+IMETHOD bool Equal(const Rotation& r1,const RotationVel& r2,double eps=epsilon);
+IMETHOD bool Equal(const RotationVel& r1,const Rotation& r2,double eps=epsilon);
+IMETHOD bool Equal(const FrameVel& r1,const FrameVel& r2,double eps=epsilon);
+IMETHOD bool Equal(const Frame& r1,const FrameVel& r2,double eps=epsilon);
+IMETHOD bool Equal(const FrameVel& r1,const Frame& r2,double eps=epsilon);
+IMETHOD bool Equal(const TwistVel& a,const TwistVel& b,double eps=epsilon);
+IMETHOD bool Equal(const Twist& a,const TwistVel& b,double eps=epsilon);
+IMETHOD bool Equal(const TwistVel& a,const Twist& b,double eps=epsilon);
+
 class VectorVel
 // = TITLE
 //     An VectorVel is a Vector and its first derivative
@@ -111,9 +125,9 @@ public:
     IMETHOD friend void SetToZero(VectorVel& v);
 
 
-    IMETHOD friend bool Equal(const VectorVel& r1,const VectorVel& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const Vector& r1,const VectorVel& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const VectorVel& r1,const Vector& r2,double eps=epsilon);
+    IMETHOD friend bool Equal(const VectorVel& r1,const VectorVel& r2,double eps);
+    IMETHOD friend bool Equal(const Vector& r1,const VectorVel& r2,double eps);
+    IMETHOD friend bool Equal(const VectorVel& r1,const Vector& r2,double eps);
     IMETHOD friend VectorVel operator - (const VectorVel& r);
     IMETHOD friend doubleVel dot(const VectorVel& lhs,const VectorVel& rhs);
     IMETHOD friend doubleVel dot(const VectorVel& lhs,const Vector& rhs);
@@ -167,9 +181,9 @@ public:
     IMETHOD friend RotationVel operator* (const RotationVel& r1,const RotationVel& r2);
     IMETHOD friend RotationVel operator* (const Rotation& r1,const RotationVel& r2);
     IMETHOD friend RotationVel operator* (const RotationVel& r1,const Rotation& r2);
-    IMETHOD friend bool Equal(const RotationVel& r1,const RotationVel& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const Rotation& r1,const RotationVel& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const RotationVel& r1,const Rotation& r2,double eps=epsilon);
+    IMETHOD friend bool Equal(const RotationVel& r1,const RotationVel& r2,double eps);
+    IMETHOD friend bool Equal(const Rotation& r1,const RotationVel& r2,double eps);
+    IMETHOD friend bool Equal(const RotationVel& r1,const Rotation& r2,double eps);
 
     IMETHOD TwistVel Inverse(const TwistVel& arg) const;
     IMETHOD TwistVel Inverse(const Twist& arg) const;
@@ -221,9 +235,9 @@ public:
     IMETHOD friend FrameVel operator * (const FrameVel& f1,const FrameVel& f2);
     IMETHOD friend FrameVel operator * (const Frame& f1,const FrameVel& f2);
     IMETHOD friend FrameVel operator * (const FrameVel& f1,const Frame& f2);
-    IMETHOD friend bool Equal(const FrameVel& r1,const FrameVel& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const Frame& r1,const FrameVel& r2,double eps=epsilon);
-    IMETHOD friend bool Equal(const FrameVel& r1,const Frame& r2,double eps=epsilon);
+    IMETHOD friend bool Equal(const FrameVel& r1,const FrameVel& r2,double eps);
+    IMETHOD friend bool Equal(const Frame& r1,const FrameVel& r2,double eps);
+    IMETHOD friend bool Equal(const FrameVel& r1,const Frame& r2,double eps);
 
     IMETHOD TwistVel  Inverse(const TwistVel& arg) const;
     IMETHOD TwistVel  Inverse(const Twist& arg) const;
@@ -293,9 +307,9 @@ public:
      // = Equality operators
      // do not use operator == because the definition of Equal(.,.) is slightly
      // different.  It compares whether the 2 arguments are equal in an eps-interval
-     IMETHOD friend bool Equal(const TwistVel& a,const TwistVel& b,double eps=epsilon);
-     IMETHOD friend bool Equal(const Twist& a,const TwistVel& b,double eps=epsilon);
-     IMETHOD friend bool Equal(const TwistVel& a,const Twist& b,double eps=epsilon);
+     IMETHOD friend bool Equal(const TwistVel& a,const TwistVel& b,double eps);
+     IMETHOD friend bool Equal(const Twist& a,const TwistVel& b,double eps);
+     IMETHOD friend bool Equal(const TwistVel& a,const Twist& b,double eps);
 
 // = Conversion to other entities
      IMETHOD Twist GetTwist() const;

--- a/orocos_kdl/src/jacobian.hpp
+++ b/orocos_kdl/src/jacobian.hpp
@@ -27,6 +27,11 @@
 
 namespace KDL
 {
+    // Equal is friend function, but default arguments for friends are forbidden (§8.3.6.4)
+    class Jacobian;
+    bool Equal(const Jacobian& a,const Jacobian& b,double eps=epsilon);
+
+
     class Jacobian
     {
     public:
@@ -46,7 +51,7 @@ namespace KDL
         bool operator ==(const Jacobian& arg)const;
         bool operator !=(const Jacobian& arg)const;
         
-        friend bool Equal(const Jacobian& a,const Jacobian& b,double eps=epsilon);
+        friend bool Equal(const Jacobian& a,const Jacobian& b,double eps);
         
 
         ~Jacobian();

--- a/orocos_kdl/src/jntarrayacc.hpp
+++ b/orocos_kdl/src/jntarrayacc.hpp
@@ -29,6 +29,10 @@
 
 namespace KDL
 {
+    // Equal is friend function, but default arguments for friends are forbidden (§8.3.6.4)
+    class JntArrayAcc;
+    bool Equal(const JntArrayAcc& src1,const JntArrayAcc& src2,double eps=epsilon);
+
     class JntArrayAcc
     {
     public:
@@ -61,7 +65,7 @@ namespace KDL
         friend void Divide(const JntArrayAcc& src,const doubleVel& factor,JntArrayAcc& dest);
         friend void Divide(const JntArrayAcc& src,const doubleAcc& factor,JntArrayAcc& dest);
         friend void SetToZero(JntArrayAcc& array);
-        friend bool Equal(const JntArrayAcc& src1,const JntArrayAcc& src2,double eps=epsilon);
+        friend bool Equal(const JntArrayAcc& src1,const JntArrayAcc& src2,double eps);
 
     };
 }

--- a/orocos_kdl/src/jntarrayvel.hpp
+++ b/orocos_kdl/src/jntarrayvel.hpp
@@ -28,7 +28,11 @@
 
 namespace KDL
 {
+    // Equal is friend function, but default arguments for friends are forbidden (§8.3.6.4)
+    class JntArrayVel;
+    bool Equal(const JntArrayVel& src1,const JntArrayVel& src2,double eps=epsilon);
 
+    
     class JntArrayVel
     {
     public:
@@ -54,7 +58,7 @@ namespace KDL
         friend void Divide(const JntArrayVel& src,const double& factor,JntArrayVel& dest);
         friend void Divide(const JntArrayVel& src,const doubleVel& factor,JntArrayVel& dest);
         friend void SetToZero(JntArrayVel& array);
-        friend bool Equal(const JntArrayVel& src1,const JntArrayVel& src2,double eps=epsilon);
+        friend bool Equal(const JntArrayVel& src1,const JntArrayVel& src2,double eps);
 
     };
 }

--- a/orocos_kdl/src/jntspaceinertiamatrix.hpp
+++ b/orocos_kdl/src/jntspaceinertiamatrix.hpp
@@ -30,6 +30,10 @@
 
 namespace KDL
 {
+    // Equal is friend function, but default arguments for friends are forbidden (§8.3.6.4)
+    class JntSpaceInertiaMatrix;
+    bool Equal(const JntSpaceInertiaMatrix& src1,const JntSpaceInertiaMatrix& src2,double eps=epsilon);
+
     /**
      * @brief This class represents an fixed size matrix containing
      * the Joint-Space Inertia Matrix of a KDL::Chain.
@@ -65,7 +69,7 @@ class MyTask : public RTT::TaskContext
 };
 /endcode
 
-     */	
+     */
 
     class JntSpaceInertiaMatrix
     {
@@ -203,7 +207,7 @@ class MyTask : public RTT::TaskContext
          * @return true if each element of src1 is within eps of the same
 		 * element in src2, or if both src1 and src2 have no data (ie 0==rows())
          */
-        friend bool Equal(const JntSpaceInertiaMatrix& src1,const JntSpaceInertiaMatrix& src2,double eps=epsilon);
+        friend bool Equal(const JntSpaceInertiaMatrix& src1,const JntSpaceInertiaMatrix& src2,double eps);
 
         friend bool operator==(const JntSpaceInertiaMatrix& src1,const JntSpaceInertiaMatrix& src2);
         //friend bool operator!=(const JntSpaceInertiaMatrix& src1,const JntSpaceInertiaMatrix& src2);


### PR DESCRIPTION
Apple updated the clang compiler toolchain again, and it seems clang is getting more strict as time goes  on. I think the change is fairly self explanatory, c++ standard §8.3.6.4 does not allow friend functions with default arguments. A quick and simple workaround it simply to use forward declarations in such instances.

This PR should not have any API or semantic changes.
