### PR TITLE
Added .travis.yml file for travis-ci support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+language: cpp
+
+compiler:
+  - gcc
+  - clang
+
+env:
+  - OROCOS_KDL_BUILD_TYPE=Debug
+  - OROCOS_KDL_BUILD_TYPE=Release
+
+before_script:
+  - sudo apt-get install -qq libeigen3-dev libcppunit-dev python-sip-dev
+  #build orocos_kdl
+  - cd orocos_kdl
+  - mkdir build
+  - cd build
+  - cmake -DENABLE_TESTS:BOOL=ON -DCMAKE_CXX_FLAGS:STRING="-Wall" -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
+  # compile and install orocos_kdl
+  - make
+  - sudo make install
+  - cd ../..
+  #build python bindings
+  - cd python_orocos_kdl
+  - mkdir build
+  - cd build
+  - cmake -DCMAKE_CXX_FLAGS:STRING="-Wall" -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
+  #compile and install python bindings
+  - make
+  - sudo make install
+  - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+  - sudo ldconfig
+  - cd ../..
+  
+
+script:
+  #execute orocos_kdl tests
+  - cd orocos_kdl/build
+  - make check
+  - cd ../..
+  #execute python bindings tests
+  - cd python_orocos_kdl/build
+  - python ../tests/PyKDLtest.py 


### PR DESCRIPTION
This travis-ci configuration file add support for building and testing both C++ and Python bindings tests, using both gcc and clang in Debug and Release builds. 
To complete the support the orocos/orocos_kinematics_dynamics repository should be enabled by the owner on https://travis-ci.org/ . 
Is possible to view an example build in https://travis-ci.org/traversaro/orocos_kinematics_dynamics/builds/21184828
