### PR TITLE
Use the FindEigen3.cmake from the Eigen repository

### DIFF
--- a/orocos_kdl/config/FindEigen3.cmake
+++ b/orocos_kdl/config/FindEigen3.cmake
@@ -9,6 +9,12 @@
 #  EIGEN3_FOUND - system has eigen lib with correct version
 #  EIGEN3_INCLUDE_DIR - the eigen include directory
 #  EIGEN3_VERSION - eigen version
+#
+# This module reads hints about search locations from 
+# the following enviroment variables:
+#
+# EIGEN3_ROOT
+# EIGEN3_ROOT_DIR
 
 # Copyright (c) 2006, 2007 Montel Laurent, <montel@kde.org>
 # Copyright (c) 2008, 2009 Gael Guennebaud, <g.gael@free.fr>
@@ -62,6 +68,9 @@ if (EIGEN3_INCLUDE_DIR)
 else (EIGEN3_INCLUDE_DIR)
 
   find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
+      HINTS
+      ENV EIGEN3_ROOT 
+      ENV EIGEN3_ROOT_DIR
       PATHS
       ${CMAKE_INSTALL_PREFIX}/include
       ${KDE4_INCLUDE_DIR}


### PR DESCRIPTION
Downloaded from [1] .
The used  `FindPackageHandleStandardArgs` CMake module is available since CMake 2.6 [2], that is already the minimum CMake version required by orocos_kdl. 

The old `FindEigen3.cmake` script is not compatible with Windows, this one should work with Windows and also cover the old use cases. 

[1] : https://bitbucket.org/eigen/eigen/src/0c883fcd96da1bcfc697bb06a421ad567689a8b2/cmake/FindEigen3.cmake
[2] : http://www.cmake.org/Wiki/CMake_Version_Compatibility_Matrix/StandardCMakeModulesFindL#cite_ref-19
