### PR TITLE
Fixes GetQuaternion non-zero matrix trace check

### DIFF
--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -197,10 +197,10 @@ namespace KDL {
     */
     void Rotation::GetQuaternion(double& x,double& y,double& z, double& w) const
     {
-        double trace = (*this)(0,0) + (*this)(1,1) + (*this)(2,2) + 1.0;
-	double epsilon=1E-12;
+        double trace = (*this)(0,0) + (*this)(1,1) + (*this)(2,2);
+        double epsilon=1E-12;
         if( trace > epsilon ){
-            double s = 0.5 / sqrt(trace);
+            double s = 0.5 / sqrt(trace + 1.0);
             w = 0.25 / s;
             x = ( (*this)(2,1) - (*this)(1,2) ) * s;
             y = ( (*this)(0,2) - (*this)(2,0) ) * s;


### PR DESCRIPTION
Currently, the matrix trace is adding 1.0 before zero (epsilon) comparison.

As noted on the referenced source: http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
And in related discussion: http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/ethan.htm

Adding the offset of 1 before epsilon comparison introduces instability as Tr + 1 approaches 0.
