### PR TITLE
Added support to RPATH for CMake >= 2.8.12

### DIFF
--- a/orocos_kdl/src/CMakeLists.txt
+++ b/orocos_kdl/src/CMakeLists.txt
@@ -74,7 +74,7 @@ IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
 
     IF(OROCOSKDL_ENABLE_RPATH)
         #Configure RPATH
-        SET(CMAKE_MACOSX_RPATH 1) #enable RPATH on OSX. This also suppress warnings on CMake >= 3.0
+        SET(CMAKE_MACOSX_RPATH TRUE) #enable RPATH on OSX. This also suppress warnings on CMake >= 3.0
         # when building, don't use the install RPATH already
         # (but later on when installing)
         SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
@@ -85,19 +85,15 @@ IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
         #I assume that the directory is
         # - install_dir/something for binaries
         # - install_dir/lib for libraries
-        FILE(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_PREFIX}/bin" "${CMAKE_INSTALL_PREFIX}/lib")
-        IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-            SET(CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
-        ELSE()
-            SET(CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
-        ENDIF()
-
-        # the RPATH to be used when installing, but only if it's not a system directory (copied form CMake File. To be tested)
         LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
         IF("${isSystemDir}" STREQUAL "-1")
-           SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+            FILE(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_PREFIX}/bin" "${CMAKE_INSTALL_PREFIX}/lib")
+            IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+                SET(CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
+            ELSE()
+                SET(CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
+            ENDIF()
         ENDIF("${isSystemDir}" STREQUAL "-1")
-
         # add the automatically determined parts of the RPATH
         # which point to directories outside the build tree to the install RPATH
         SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) #very important!

--- a/orocos_kdl/src/CMakeLists.txt
+++ b/orocos_kdl/src/CMakeLists.txt
@@ -61,15 +61,73 @@ ENDIF(MSVC)
 
 CONFIGURE_FILE(config.h.in config.h @ONLY)
 
+#### Settings for rpath
+IF(${CMAKE_MINIMUM_REQUIRED_VERSION} VERSION_GREATER "2.8.12")
+    MESSAGE(AUTHOR_WARNING "CMAKE_MINIMUM_REQUIRED_VERSION is now ${CMAKE_MINIMUM_REQUIRED_VERSION}. This check can be removed.")
+ENDIF()
+IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
+    IF(NOT MSVC)
+        #add the option to disable RPATH
+        OPTION(OROCOSKDL_ENABLE_RPATH "Enable RPATH during installation" FALSE)
+        MARK_AS_ADVANCED(OROCOSKDL_ENABLE_RPATH)
+    ENDIF(NOT MSVC)
+
+    IF(OROCOSKDL_ENABLE_RPATH)
+        #Configure RPATH
+        SET(CMAKE_MACOSX_RPATH 1) #enable RPATH on OSX. This also suppress warnings on CMake >= 3.0
+        # when building, don't use the install RPATH already
+        # (but later on when installing)
+        SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+        #build directory by default is built with RPATH
+        SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+        #This is relative RPATH for libraries built in the same project
+        #I assume that the directory is
+        # - install_dir/something for binaries
+        # - install_dir/lib for libraries
+        FILE(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_PREFIX}/bin" "${CMAKE_INSTALL_PREFIX}/lib")
+        IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            SET(CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
+        ELSE()
+            SET(CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
+        ENDIF()
+
+        # the RPATH to be used when installing, but only if it's not a system directory (copied form CMake File. To be tested)
+        LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+        IF("${isSystemDir}" STREQUAL "-1")
+           SET(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
+        ENDIF("${isSystemDir}" STREQUAL "-1")
+
+        # add the automatically determined parts of the RPATH
+        # which point to directories outside the build tree to the install RPATH
+        SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) #very important!
+    ENDIF()
+ENDIF()
+#####end RPATH
+
 ADD_LIBRARY(orocos-kdl ${LIB_TYPE} ${KDL_SRCS} config.h)
- 
+
 SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
   SOVERSION "${KDL_VERSION_MAJOR}.${KDL_VERSION_MINOR}"
   VERSION "${KDL_VERSION}"
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS}"
-  INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}"
   PUBLIC_HEADER "${KDL_HPPS};${CMAKE_CURRENT_BINARY_DIR}/config.h"
   )
+
+#### Settings for rpath disabled (back-compatibility)
+IF(${CMAKE_MINIMUM_REQUIRED_VERSION} VERSION_GREATER "2.8.12")
+    MESSAGE(AUTHOR_WARNING "CMAKE_MINIMUM_REQUIRED_VERSION is now ${CMAKE_MINIMUM_REQUIRED_VERSION}. This check can be removed.")
+ENDIF()
+IF(CMAKE_VERSION VERSION_LESS 2.8.12)
+    SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
+      INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
+ELSE()
+    IF(NOT OROCOSKDL_ENABLE_RPATH)
+        SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
+          INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
+    ENDIF()
+ENDIF()
+#####end RPATH
 
 # Needed so that the generated config.h can be used
 INCLUDE_DIRECTORIES(${CMAKE_CURRENT_BINARY_DIR})


### PR DESCRIPTION
CMake 2.8.12 changed how `RPATH` is handled (at least for OS X). Furthermore in CMake 3.0 a warning is issued if these changes are not integrated (or the policy disabled).

Using `RPATH` avoids messing with the linker search path in environmental variables.

My patch should be backcompatible: `RPATH` is disabled by default and is supported only on CMake >= 2.8.12.
In case CMake is less recent or (by default) `RPATH` is not chosen, it behaves as before (so it keeps also the CMake warning).

Compiling and installing with `RPATH` on OS X gives the following results:
```bash
$ otool -D liborocos-kdl.dylib 
liborocos-kdl.dylib:
@rpath/liborocos-kdl.1.3.dylib
```
In this way the library is relocable (the library name does not contain the absolute path to the library).

Just one note in this PR:
Lines from 88 to 99 are needed only if KDL links to other non-system libraries (which currently it does not). But they should not harm if kept.

