### PR TITLE
Use SolverI interface for chainidsolvers

### DIFF
--- a/orocos_kdl/src/chainidsolver.hpp
+++ b/orocos_kdl/src/chainidsolver.hpp
@@ -25,6 +25,7 @@
 #include "chain.hpp"
 #include "frames.hpp"
 #include "jntarray.hpp"
+#include "solveri.hpp"
 
 namespace KDL
 {
@@ -36,7 +37,7 @@ namespace KDL
 	 * dynamics solver for a KDL::Chain.
 	 *
 	 */
-	class ChainIdSolver
+	class ChainIdSolver : public KDL::SolverI
 	{
 		public:
 			/** 

--- a/orocos_kdl/src/chainidsolver_recursive_newton_euler.cpp
+++ b/orocos_kdl/src/chainidsolver_recursive_newton_euler.cpp
@@ -35,7 +35,7 @@ namespace KDL{
     {
         //Check sizes when in debug mode
         if(q.rows()!=nj || q_dot.rows()!=nj || q_dotdot.rows()!=nj || torques.rows()!=nj || f_ext.size()!=ns)
-            return -1;
+            return (error = -1);
         unsigned int j=0;
 
         //Sweep from root to leaf
@@ -79,6 +79,6 @@ namespace KDL{
             if(i!=0)
                 f[i-1]=f[i-1]+X[i]*f[i];
         }
-	return 0;
+	return (error = E_NOERROR);
     }
 }//namespace

--- a/orocos_kdl/src/solveri.hpp
+++ b/orocos_kdl/src/solveri.hpp
@@ -114,6 +114,8 @@ public:
 	{
 		if (E_NOERROR == error) return "No error";
 		else if (E_NO_CONVERGE == error) return "Failed to converge";
+		else if (E_UNDEFINED == error) return "Undefined value";
+		else if (E_DEGRADED == error) return "Converged but degraded solution";
 		else return "UNKNOWN ERROR";
 	}
 


### PR DESCRIPTION
The chain FK and IK solvers already use this interface, and this ensures that the chain ID solvers do as well.

Also contains a small fix to the SolverI interface to provide descriptions of all SolverI error codes.