### PR TITLE
Jacobian Time Derivative (Jdot) Solver 

### DIFF
--- a/orocos_kdl/src/chainjnttojacdotsolver.cpp
+++ b/orocos_kdl/src/chainjnttojacdotsolver.cpp
@@ -124,7 +124,7 @@ int ChainJntToJacDotSolver::JntToJacDot(const JntArrayVel& q_in, Jacobian& jdot,
 const Twist& ChainJntToJacDotSolver::getPartialDerivative(const KDL::Jacobian& J, 
                                                           const unsigned int& joint_idx, 
                                                           const unsigned int& column_idx, 
-                                                          const unsigned int& representation)
+                                                          const int& representation)
 {
     switch(representation)
     {
@@ -203,7 +203,9 @@ const Twist& ChainJntToJacDotSolver::getPartialDerivativeBodyFixed(const Jacobia
 
         return t_djdq_;
 }
-const Twist& ChainJntToJacDotSolver::getPartialDerivativeInertial(const KDL::Jacobian& bs_J_bs, const unsigned int& joint_idx, const unsigned int& column_idx)
+const Twist& ChainJntToJacDotSolver::getPartialDerivativeInertial(const KDL::Jacobian& bs_J_bs, 
+                                                                  const unsigned int& joint_idx, 
+                                                                  const unsigned int& column_idx)
 {
         int j=joint_idx;
         int i=column_idx;
@@ -225,7 +227,7 @@ const Twist& ChainJntToJacDotSolver::getPartialDerivativeInertial(const KDL::Jac
         
         return t_djdq_;
 }
-void ChainJntToJacDotSolver::setRepresentation(const unsigned int& representation)
+void ChainJntToJacDotSolver::setRepresentation(const int& representation)
 {
     if(representation == HYBRID ||
         representation == BODYFIXED ||

--- a/orocos_kdl/src/chainjnttojacdotsolver.cpp
+++ b/orocos_kdl/src/chainjnttojacdotsolver.cpp
@@ -1,0 +1,260 @@
+/*
+    Computes the Jacobian time derivative
+    Copyright (C) 2015  Antoine Hoarau <hoarau [at] isir.upmc.fr>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+
+#include "chainjnttojacdotsolver.hpp"
+#include "chainfksolverpos_recursive.hpp"
+#include "chainjnttojacsolver.hpp"
+//#include "kinfam_io.hpp"
+//#include "frames_io.hpp"
+//#include "framevel_io.hpp"
+
+namespace KDL
+{
+
+inline void Skew(Rotation& R,const Vector& sk)
+{
+    R(0,0) = 0.0;
+    R(0,1) = - sk.z();
+    R(0,2) =   sk.y();
+    R(1,0) =   sk.z();
+    R(1,1) = 0.0;
+    R(1,2) = - sk.x();
+    R(2,0) = - sk.y();
+    R(2,1) =   sk.x();
+    R(2,2) = 0.0;    
+}
+
+ChainJntToJacDotSolver::ChainJntToJacDotSolver(const Chain& _chain):
+chain(_chain),
+locked_joints_(chain.getNrOfJoints(),false),
+nr_of_unlocked_joints_(chain.getNrOfJoints()),
+jac_solver_(chain),
+jac_(chain.getNrOfJoints()),
+jac_dot_(chain.getNrOfJoints()),
+representation_(HYBRID),
+fk_solver_(chain)
+{
+
+}
+
+int ChainJntToJacDotSolver::JntToJacDot(const JntArrayVel& q_in, Twist& jac_dot_q_dot, int seg_nr)
+{
+    JntToJacDot(q_in,jac_dot_,seg_nr);
+    MultiplyJacobian(jac_dot_,q_in.qdot,jac_dot_q_dot);
+    return (error = E_NOERROR);
+}
+
+int ChainJntToJacDotSolver::JntToJacDot(const JntArrayVel& q_in, Jacobian& jdot, int seg_nr)
+{
+        unsigned int segmentNr;
+        if(seg_nr<0)
+            segmentNr=chain.getNrOfSegments();
+        else
+            segmentNr = seg_nr;
+
+        //Initialize Jacobian to zero since only segmentNr colunns are computed
+        SetToZero(jdot) ;
+
+        if(q_in.q.rows()!=chain.getNrOfJoints()||nr_of_unlocked_joints_!=jdot.columns())
+            return (error = E_JAC_DOT_FAILED);
+        else if(segmentNr>chain.getNrOfSegments())
+            return (error = E_JAC_DOT_FAILED);
+                      
+        // First compute the jacobian in the Hybrid representation
+        jac_solver_.JntToJac(q_in.q,jac_,segmentNr);
+        
+        // Change the reference frame and/or the reference point
+        switch(representation_)
+        {
+            case HYBRID:
+                // Do Nothing as it is the default in KDL;
+                break;
+            case BODYFIXED:
+                // Ref Frame {ee}, Ref Point {ee}
+                fk_solver_.JntToCart(q_in.q,F_bs_ee_,segmentNr);
+                jac_.changeBase(F_bs_ee_.M.Inverse());
+                break;
+            case INTERTIAL:
+                // Ref Frame {bs}, Ref Point {bs}
+                fk_solver_.JntToCart(q_in.q,F_bs_ee_,segmentNr);
+                jac_.changeRefPoint(-F_bs_ee_.p);
+                break;
+            default:
+                return (error = E_JAC_DOT_FAILED);
+        }
+        
+        // Let's compute Jdot in the corresponding representation
+        int k=0;
+        for(unsigned int i=0;i<segmentNr;++i)
+        {
+            //Only increase joint nr if the segment has a joint
+            if(chain.getSegment(i).getJoint().getType()!=Joint::None){
+                
+                for(unsigned int j=0;j<chain.getNrOfJoints();++j)
+                {
+                    // Column J is the sum of all partial derivatives  ref (41)
+                    if(!locked_joints_[j])
+                        jac_dot_k_ += getPartialDerivative(jac_,j,k,representation_) * q_in.qdot(j);
+                }
+                jdot.setColumn(k++,jac_dot_k_);
+                SetToZero(jac_dot_k_);
+            }
+        }
+        
+        return (error = E_NOERROR);
+}
+
+const Twist& ChainJntToJacDotSolver::getPartialDerivative(const KDL::Jacobian& J, 
+                                                          const unsigned int& joint_idx, 
+                                                          const unsigned int& column_idx, 
+                                                          const unsigned int& representation)
+{
+    switch(representation)
+    {
+        case HYBRID:
+            return getPartialDerivativeHybrid(J,joint_idx,column_idx);
+        case BODYFIXED:
+            return getPartialDerivativeBodyFixed(J,joint_idx,column_idx);
+        case INTERTIAL:
+            return getPartialDerivativeInertial(J,joint_idx,column_idx);
+        default:
+            SetToZero(this->t_djdq_);
+            return t_djdq_;
+    }
+}
+
+const Twist& ChainJntToJacDotSolver::getPartialDerivativeHybrid(const KDL::Jacobian& bs_J_ee, 
+                                                                const unsigned int& joint_idx, 
+                                                                const unsigned int& column_idx)
+{
+        int j=joint_idx;
+        int i=column_idx;
+        
+        jac_j_ = bs_J_ee.getColumn(j);
+        jac_i_ = bs_J_ee.getColumn(i);
+        
+        SetToZero(t_djdq_);
+        
+        if(j < i)
+        {
+            // P_{\Delta}({}_{bs}J^{j})  ref (20)
+            Skew(e_j_skew_,jac_j_.rot);
+            t_djdq_.vel = e_j_skew_ * jac_i_.vel;
+            t_djdq_.rot = e_j_skew_ * jac_i_.rot;
+            
+        }else if(j > i)
+        {
+            // M_{\Delta}({}_{bs}J^{j})  ref (23)
+            Skew(v_j_skew_,-jac_j_.vel);
+            SetToZero(t_djdq_.rot);
+            t_djdq_.vel = v_j_skew_ * jac_i_.rot;
+
+            
+        }else if(j == i)
+        {
+             // ref (40)
+             SetToZero(t_djdq_.rot);
+             t_djdq_.vel = jac_i_.rot * (jac_i_.vel);
+        }
+        
+        return t_djdq_;
+
+}
+
+const Twist& ChainJntToJacDotSolver::getPartialDerivativeBodyFixed(const Jacobian& ee_J_ee, 
+                                                            const unsigned int& joint_idx, 
+                                                            const unsigned int& column_idx)
+{
+        int j=joint_idx;
+        int i=column_idx;
+
+        SetToZero(t_djdq_);
+        
+        if(j > i)
+        {
+            jac_j_ = ee_J_ee.getColumn(j);
+            jac_i_ = ee_J_ee.getColumn(i);
+        
+            // - S_d_(ee_J^j) * ee_J^ee  ref (23)
+            Skew(v_j_skew_,jac_j_.vel);
+            Skew(e_j_skew_,jac_j_.rot);
+            
+            t_djdq_.vel = e_j_skew_ * jac_i_.vel + v_j_skew_ * jac_i_.rot;
+            t_djdq_.rot = e_j_skew_ * jac_i_.rot;
+            t_djdq_ = -t_djdq_;
+        }
+
+        return t_djdq_;
+}
+const Twist& ChainJntToJacDotSolver::getPartialDerivativeInertial(const KDL::Jacobian& bs_J_bs, const unsigned int& joint_idx, const unsigned int& column_idx)
+{
+        int j=joint_idx;
+        int i=column_idx;
+        
+        SetToZero(t_djdq_);
+        
+        if(j < i)
+        {
+            jac_j_ = bs_J_bs.getColumn(j);
+            jac_i_ = bs_J_bs.getColumn(i);
+        
+            // S_d_(bs_J^j) * bs_J^bs  ref (23)
+            Skew(v_j_skew_,jac_j_.vel);
+            Skew(e_j_skew_,jac_j_.rot);
+            
+            t_djdq_.vel = e_j_skew_ * jac_i_.vel + v_j_skew_ * jac_i_.rot;
+            t_djdq_.rot = e_j_skew_ * jac_i_.rot;
+        }
+        
+        return t_djdq_;
+}
+void ChainJntToJacDotSolver::setRepresentation(const unsigned int& representation)
+{
+    if(representation == HYBRID ||
+        representation == BODYFIXED ||
+        representation == INTERTIAL)   
+    this->representation_ = representation;
+}
+
+
+int ChainJntToJacDotSolver::setLockedJoints(const std::vector< bool > locked_joints)
+{
+    if(locked_joints.size()!=locked_joints_.size())
+        return -1;
+    locked_joints_=locked_joints;
+    nr_of_unlocked_joints_=0;
+    for(unsigned int i=0;i<locked_joints_.size();i++){
+        if(!locked_joints_[i])
+            nr_of_unlocked_joints_++;
+    }
+
+    return 0;
+}
+const char* ChainJntToJacDotSolver::strError(const int error) const
+{
+        if (E_JAC_DOT_FAILED == error) return "Jac Dot Failed";
+        else return SolverI::strError(error);
+}
+
+ChainJntToJacDotSolver::~ChainJntToJacDotSolver()
+{
+
+}
+}

--- a/orocos_kdl/src/chainjnttojacdotsolver.hpp
+++ b/orocos_kdl/src/chainjnttojacdotsolver.hpp
@@ -105,7 +105,7 @@ public:
      * @param representation The representation for Jdot : HYBRID,BODYFIXED or INTERTIAL
      * @return void
      */
-    void setRepresentation(const unsigned int& representation);
+    void setRepresentation(const int& representation);
     
     /// @copydoc KDL::SolverI::strError()
     virtual const char* strError(const int error) const;
@@ -155,7 +155,7 @@ protected:
     const Twist& getPartialDerivative(const Jacobian& J,
                                const unsigned int& joint_idx,
                                const unsigned int& column_idx,
-                               const unsigned int& representation);
+                               const int& representation);
 private:
     
     const Chain chain;
@@ -164,7 +164,7 @@ private:
     ChainJntToJacSolver jac_solver_;
     Jacobian jac_;
     Jacobian jac_dot_;
-    unsigned int representation_;
+    int representation_;
     ChainFkSolverPos_recursive fk_solver_;
     Frame F_bs_ee_;
     Twist jac_dot_k_;

--- a/orocos_kdl/src/chainjnttojacdotsolver.hpp
+++ b/orocos_kdl/src/chainjnttojacdotsolver.hpp
@@ -1,0 +1,177 @@
+/*
+    Computes the Jacobian time derivative
+    Copyright (C) 2015  Antoine Hoarau <hoarau [at] isir.upmc.fr>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+
+#ifndef KDL_CHAINJNTTOJACDOTSOLVER_HPP
+#define KDL_CHAINJNTTOJACDOTSOLVER_HPP
+
+#include "solveri.hpp"
+#include "frames.hpp"
+#include "jntarrayvel.hpp"
+#include "jacobian.hpp"
+#include "chain.hpp"
+#include "framevel.hpp"
+#include "chainjnttojacsolver.hpp"
+#include "chainfksolverpos_recursive.hpp"
+
+namespace KDL
+{
+    
+class ChainJntToJacDotSolver : public SolverI
+{
+/*
+ * Computes the Jacobian time derivative (Jdot) by calculating the partial derivatives
+ * regarding to a joint angle, in the Hybrid, Body-fixed or Inertial representation. 
+ * This work is based on : 
+ * 
+ * Symbolic differentiation of the velocity mapping for a serial kinematic chain
+ * H. Bruyninckx, J. De Schutter
+ * doi:10.1016/0094-114X(95)00069-B
+ * 
+ * url : http://www.sciencedirect.com/science/article/pii/0094114X9500069B
+*/
+public:
+    static const int E_JAC_DOT_FAILED= -100;
+    
+    // Hybrid representation ref Frame: base, ref Point: end-effector
+    static const int HYBRID = 0;
+    // Body-fixed representation ref Frame: end-effector, ref Point: end-effector
+    static const int BODYFIXED = 1;
+    // Intertial representation ref Frame: base, ref Point: base
+    static const int INTERTIAL = 2;
+    
+    explicit ChainJntToJacDotSolver(const Chain& chain);
+    virtual ~ChainJntToJacDotSolver();
+    /**
+     * @brief Computes \f$ {}_{bs}\dot{J}^{ee}.\dot{q} \f$
+     * 
+     * @param q_in Current joint positions and velocities
+     * @param jac_dot_q_dot The twist representing Jdot*qdot
+     * @param seg_nr The final segment to compute
+     * @return int 0 if no errors happened 
+     */
+    virtual int JntToJacDot(const KDL::JntArrayVel& q_in, KDL::Twist& jac_dot_q_dot, int seg_nr = -1);
+    /**
+     * @brief Computes \f$ {}_{bs}\dot{J}^{ee} \f$ 
+     * 
+     * @param q_in Current joint positions and velocities
+     * @param jdot The jacobian time derivative in Hybrid representation 
+     *        (i.e. with the base frame as the reference frame and the end effector frame 
+     * as the velocity reference frame 
+     * @param seg_nr The final segment to compute
+     * @return int 0 if no errors happened
+     */
+    virtual int JntToJacDot(const KDL::JntArrayVel& q_in, KDL::Jacobian& jdot, int seg_nr = -1);
+    int setLockedJoints(const std::vector<bool> locked_joints);
+    
+    /**
+     * @brief JntToJacDot() will compute in the Hybrid representation (ref Frame: base, ref Point: end-effector)
+     * 
+     * 
+     * @return void
+     */
+    void setHybridRepresentation(){setRepresentation(HYBRID);}
+    /**
+     * @brief JntToJacDot() will compute in the Body-fixed representation (ref Frame: end-effector, ref Point: end-effector)
+     * 
+     * @return void
+     */
+    void setBodyFixedRepresentation(){setRepresentation(BODYFIXED);}
+    /**
+     * @brief JntToJacDot() will compute in the Inertial representation (ref Frame: base, ref Point: base)
+     * 
+     * @return void
+     */
+    void setInternialRepresentation(){setRepresentation(INTERTIAL);}
+    /**
+     * @brief Sets the internal variable for the representation (with a check on the value)
+     * 
+     * @param representation The representation for Jdot : HYBRID,BODYFIXED or INTERTIAL
+     * @return void
+     */
+    void setRepresentation(const unsigned int& representation);
+    
+    /// @copydoc KDL::SolverI::strError()
+    virtual const char* strError(const int error) const;
+protected:
+     /**
+     * @brief Computes \f$ \frac{\partial {}_{bs}J^{i,ee}}{\partial q^{j}}.\dot{q}^{j} \f$
+     * 
+     * @param bs_J_ee The Jacobian expressed in the base frame with the end effector as the reference point (default in KDL Jacobian Solver)
+     * @param joint_idx The indice of the current joint (j in the formula)
+     * @param column_idx The indice of the current column (i in the formula)
+     * @return Twist The twist representing dJi/dqj .qdotj
+     */
+    const Twist& getPartialDerivativeHybrid(const Jacobian& bs_J_ee,
+                                     const unsigned int& joint_idx,
+                                     const unsigned int& column_idx);
+     /**
+     * @brief Computes \f$ \frac{\partial {}_{ee}J^{i,ee}}{\partial q^{j}}.\dot{q}^{j} \f$
+     * 
+     * @param bs_J_ee The Jacobian expressed in the end effector frame with the end effector as the reference point
+     * @param joint_idx The indice of the current joint (j in the formula)
+     * @param column_idx The indice of the current column (i in the formula)
+     * @return Twist The twist representing dJi/dqj .qdotj
+     */    
+    const Twist& getPartialDerivativeBodyFixed(const Jacobian& ee_J_ee,
+                                        const unsigned int& joint_idx,
+                                        const unsigned int& column_idx);
+     /**
+     * @brief Computes \f$ \frac{\partial {}_{bs}J^{i,bs}}{\partial q^{j}}.\dot{q}^{j} \f$
+     * 
+     * @param ee_J_ee The Jacobian expressed in the base frame with the base as the reference point
+     * @param joint_idx The indice of the current joint (j in the formula)
+     * @param column_idx The indice of the current column (i in the formula)
+     * @return Twist The twist representing dJi/dqj .qdotj
+     */    
+    const Twist& getPartialDerivativeInertial(const Jacobian& bs_J_bs,
+                                       const unsigned int& joint_idx,
+                                       const unsigned int& column_idx);
+     /**
+     * @brief Computes \f$ \frac{\partial J^{i,ee}}{\partial q^{j}}.\dot{q}^{j} \f$
+     * 
+     * @param bs_J_bs The Jacobian expressed in the base frame with the end effector as the reference point
+     * @param joint_idx The indice of the current joint (j in the formula)
+     * @param column_idx The indice of the current column (i in the formula)
+     * @param representation The representation (Hybrid,Body-fixed,Inertial) in which you want to get dJ/dqj .qdotj 
+     * @return Twist The twist representing dJi/dqj .qdotj
+     */    
+    const Twist& getPartialDerivative(const Jacobian& J,
+                               const unsigned int& joint_idx,
+                               const unsigned int& column_idx,
+                               const unsigned int& representation);
+private:
+    
+    const Chain chain;
+    std::vector<bool> locked_joints_;
+    unsigned int nr_of_unlocked_joints_;
+    ChainJntToJacSolver jac_solver_;
+    Jacobian jac_;
+    Jacobian jac_dot_;
+    unsigned int representation_;
+    ChainFkSolverPos_recursive fk_solver_;
+    Frame F_bs_ee_;
+    Twist jac_dot_k_;
+    Rotation e_j_skew_,v_j_skew_;
+    Twist jac_j_,jac_i_;
+    Twist t_djdq_;
+};
+
+}
+#endif

--- a/orocos_kdl/tests/CMakeLists.txt
+++ b/orocos_kdl/tests/CMakeLists.txt
@@ -38,6 +38,13 @@ IF(ENABLE_TESTS)
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
  ADD_TEST(jacobiantest jacobiantest)
 
+ ADD_EXECUTABLE(jacobiandottest jacobiandottest.cpp test-runner.cpp)
+ SET(TESTNAME "jacobiandottest")
+ TARGET_LINK_LIBRARIES(jacobiandottest orocos-kdl ${CPPUNIT})
+ SET_TARGET_PROPERTIES( jacobiandottest PROPERTIES
+  COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
+ ADD_TEST(jacobiandottest jacobiandottest)
+ 
  ADD_EXECUTABLE(velocityprofiletest velocityprofiletest.cpp test-runner.cpp)
  SET(TESTNAME "velocityprofiletest")
  TARGET_LINK_LIBRARIES(velocityprofiletest orocos-kdl ${CPPUNIT})

--- a/orocos_kdl/tests/jacobiandottest.cpp
+++ b/orocos_kdl/tests/jacobiandottest.cpp
@@ -90,7 +90,7 @@ namespace KDL{
 }
 
 
-void changeRepresentation(Jacobian& J,const Frame& F_bs_ee,const unsigned int& representation)
+void changeRepresentation(Jacobian& J,const Frame& F_bs_ee,const int& representation)
 {
     switch(representation)
     {
@@ -157,7 +157,7 @@ void random(JntArray& q)
         random(q(i));
 }
 
-double compare_Jdot_Diff_vs_Solver(const Chain& chain,const double& dt,const unsigned int& representation,bool verbose)
+double compare_Jdot_Diff_vs_Solver(const Chain& chain,const double& dt,const int& representation,bool verbose)
 {
     // This test verifies if the solvers gives approx. the same result as [ J(q+qdot*dot) - J(q) ]/dot
     JntArray q(chain.getNrOfJoints());
@@ -242,12 +242,12 @@ double compare_d2_Jdot_Symbolic_vs_Solver(bool verbose)
     return std::abs(err);    
 }
 
-bool runTest(const Chain& chain,const unsigned int& representation)
+bool runTest(const Chain& chain,const int& representation)
 {
     bool success=true;
     bool verbose = false;
     double err;
-    bool print_err = true;
+    bool print_err = false;
     
     for(double dt=1e-6;dt<0.1;dt*=10)
     {
@@ -275,32 +275,32 @@ bool runTest(const Chain& chain,const unsigned int& representation)
 }
 
 void JacobianDotTest::testD2DiffHybrid(){
-    CPPUNIT_ASSERT(runTest(d2(),ChainJntToJacDotSolver::HYBRID));
+    CPPUNIT_ASSERT(runTest(d2(),0));
 }
 void JacobianDotTest::testD6DiffHybrid(){
-    CPPUNIT_ASSERT(runTest(d6(),ChainJntToJacDotSolver::HYBRID));
+    CPPUNIT_ASSERT(runTest(d6(),0));
 }
 void JacobianDotTest::testKukaDiffHybrid(){
-    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),ChainJntToJacDotSolver::HYBRID));
+    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),0));
 }
 
 void JacobianDotTest::testD2DiffInertial(){
-    CPPUNIT_ASSERT(runTest(d2(),ChainJntToJacDotSolver::INTERTIAL));
+    CPPUNIT_ASSERT(runTest(d2(),2));
 }
 void JacobianDotTest::testD6DiffInertial(){
-    CPPUNIT_ASSERT(runTest(d6(),ChainJntToJacDotSolver::INTERTIAL));
+    CPPUNIT_ASSERT(runTest(d6(),2));
 }
 void JacobianDotTest::testKukaDiffInertial(){
-    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),ChainJntToJacDotSolver::INTERTIAL));
+    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),2));
 }
 void JacobianDotTest::testD2DiffBodyFixed(){
-    CPPUNIT_ASSERT(runTest(d2(),ChainJntToJacDotSolver::BODYFIXED));
+    CPPUNIT_ASSERT(runTest(d2(),1));
 }
 void JacobianDotTest::testD6DiffBodyFixed(){
-    CPPUNIT_ASSERT(runTest(d6(),ChainJntToJacDotSolver::BODYFIXED));
+    CPPUNIT_ASSERT(runTest(d6(),1));
 }
 void JacobianDotTest::testKukaDiffBodyFixed(){
-    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),ChainJntToJacDotSolver::BODYFIXED));
+    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),1));
 }
 
 void JacobianDotTest::testD2Symbolic(){
@@ -308,7 +308,7 @@ void JacobianDotTest::testD2Symbolic(){
     bool success=true;
     bool verbose = false;
     double err_d2_sym;
-    bool print_err = true;
+    bool print_err = false;
     
     double eps_sym_vs_solver = 1e-10;
     

--- a/orocos_kdl/tests/jacobiandottest.cpp
+++ b/orocos_kdl/tests/jacobiandottest.cpp
@@ -1,0 +1,331 @@
+#include "jacobiandottest.hpp"
+
+CPPUNIT_TEST_SUITE_REGISTRATION(JacobianDotTest);
+
+using namespace KDL;
+
+void JacobianDotTest::setUp(){}
+void JacobianDotTest::tearDown(){}
+
+
+namespace KDL{
+        static const double L0 = 1.0;
+        static const double L1 = 0.5;
+        static const double L2 = 0.4;
+        static const double L3 = 0;
+        static const double L4 = 0;
+        static const double L5 = 0;
+    Chain d2(){
+        Chain d2;
+        d2.addSegment(Segment(Joint(Joint::RotZ),Frame(Vector(L0,0,0))));
+        d2.addSegment(Segment(Joint(Joint::RotZ),Frame(Vector(L1,0,0))));
+        return d2;
+    }
+    Chain d6(){
+        Chain d6;
+        d6.addSegment(Segment(Joint(Joint::RotZ),Frame(Vector(L0,0,0))));
+        d6.addSegment(Segment(Joint(Joint::RotX),Frame(Vector(L1,0,0))));
+        d6.addSegment(Segment(Joint(Joint::RotX),Frame(Vector(L2,0,0))));
+        d6.addSegment(Segment(Joint(Joint::RotZ),Frame(Vector(L3,0,0))));
+        d6.addSegment(Segment(Joint(Joint::RotX),Frame(Vector(L4,0,0))));
+        d6.addSegment(Segment(Joint(Joint::RotZ),Frame(Vector(L5,0,0))));
+        return d6;
+    }
+    Chain KukaLWR_DHnew(){
+        Chain kukaLWR_DHnew;
+        
+        //joint 0
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::None),
+                                  Frame::DH_Craig1989(0.0, 0.0, 0.31, 0.0)
+                                  ));
+        //joint 1
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::RotZ),
+                                  Frame::DH_Craig1989(0.0, 1.5707963, 0.0, 0.0),
+                                  Frame::DH_Craig1989(0.0, 1.5707963, 0.0, 0.0).Inverse()*RigidBodyInertia(2,
+                                                                                                 Vector::Zero(),
+                                                                                                 RotationalInertia(0.0,0.0,0.0115343,0.0,0.0,0.0))));
+                                   
+        //joint 2 
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::RotZ),
+                                  Frame::DH_Craig1989(0.0, -1.5707963, 0.4, 0.0),
+                                  Frame::DH_Craig1989(0.0, -1.5707963, 0.4, 0.0).Inverse()*RigidBodyInertia(2,
+                                                                                                   Vector(0.0,-0.3120511,-0.0038871),
+                                                                                                   RotationalInertia(-0.5471572,-0.0000302,-0.5423253,0.0,0.0,0.0018828))));
+                                  
+        //joint 3
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::RotZ),
+                                  Frame::DH_Craig1989(0.0, -1.5707963, 0.0, 0.0),
+                                  Frame::DH_Craig1989(0.0, -1.5707963, 0.0, 0.0).Inverse()*RigidBodyInertia(2,
+                                                                                                   Vector(0.0,-0.0015515,0.0),
+                                                                                                   RotationalInertia(0.0063507,0.0,0.0107804,0.0,0.0,-0.0005147))));
+                                  
+        //joint 4
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::RotZ),
+                                  Frame::DH_Craig1989(0.0, 1.5707963, 0.39, 0.0),
+                                  Frame::DH_Craig1989(0.0, 1.5707963, 0.39, 0.0).Inverse()*RigidBodyInertia(2,
+                                                                                                   Vector(0.0,0.5216809,0.0),
+                                                                                                   RotationalInertia(-1.0436952,0.0,-1.0392780,0.0,0.0,0.0005324))));
+                                  
+        //joint 5
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::RotZ),
+                                  Frame::DH_Craig1989(0.0, 1.5707963, 0.0, 0.0),
+                                  Frame::DH_Craig1989(0.0, 1.5707963, 0.0, 0.0).Inverse()*RigidBodyInertia(2,
+                                                                                                   Vector(0.0,0.0119891,0.0),
+                                                                                                   RotationalInertia(0.0036654,0.0,0.0060429,0.0,0.0,0.0004226))));
+                                  
+        //joint 6
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::RotZ),
+                                  Frame::DH_Craig1989(0.0, -1.5707963, 0.0, 0.0),
+                                  Frame::DH_Craig1989(0.0, -1.5707963, 0.0, 0.0).Inverse()*RigidBodyInertia(2,
+                                                                                                   Vector(0.0,0.0080787,0.0),
+                                                                                                   RotationalInertia(0.0010431,0.0,0.0036376,0.0,0.0,0.0000101))));
+        //joint 7
+        kukaLWR_DHnew.addSegment(Segment(Joint(Joint::RotZ),
+                                   Frame::Identity(),
+                                   RigidBodyInertia(2,
+                                                                                                   Vector::Zero(),
+                                                                                                   RotationalInertia(0.000001,0.0,0.0001203,0.0,0.0,0.0))));
+        return kukaLWR_DHnew;
+    }    
+}
+
+
+void changeRepresentation(Jacobian& J,const Frame& F_bs_ee,const unsigned int& representation)
+{
+    switch(representation)
+    {
+        case ChainJntToJacDotSolver::HYBRID:
+            break;
+        case ChainJntToJacDotSolver::BODYFIXED:
+            // Ref Frame {ee}, Ref Point {ee}
+            J.changeBase(F_bs_ee.M.Inverse());
+            break;
+        case ChainJntToJacDotSolver::INTERTIAL:
+            // Ref Frame {bs}, Ref Point {bs}
+            J.changeRefPoint(-F_bs_ee.p);
+            break;
+    }
+}
+void Jdot_diff(const Jacobian& J_q,
+                     const Jacobian& J_qdt,
+                     const double& dt,
+                     Jacobian& Jdot)
+{
+    assert(J_q.columns() == J_qdt.columns());
+    assert(J_q.columns() == Jdot.columns());
+    for(int l=0;l<6;l++)
+    for(int c=0;c<J_q.columns();c++)
+        Jdot(l,c) = (J_qdt(l,c) - J_q(l,c))/dt;
+}
+
+Jacobian Jdot_d2_symbolic(const JntArray& q,const JntArray& qdot)
+{
+    // Returns Jdot for the simple 2DOF arm 
+    Jacobian Jdot(q.rows());
+    SetToZero(Jdot);
+    Jdot(0,0) =  -L1 * (qdot(0) + qdot(1))*cos(q(0)+q(1))-L0*cos(q(0))*qdot(0);
+    Jdot(0,1) =  -L1 * (qdot(0) + qdot(1))*cos(q(0)+q(1));
+    Jdot(1,0) =  -L1 * (qdot(0) + qdot(1))*sin(q(0)+q(1))-L0*sin(q(0))*qdot(0);
+    Jdot(1,1) =  -L1 * (qdot(0) + qdot(1))*sin(q(0)+q(1));
+    return Jdot;
+}
+
+Jacobian J_d2_symbolic(const JntArray& q,const JntArray& qdot)
+{
+    // Returns J for the simple 2DOF arm
+    Jacobian J(q.rows());
+    SetToZero(J);
+    J(0,0) =  -L1 * sin(q(0)+q(1))-L0*sin(q(0));
+    J(0,1) =  -L1 * sin(q(0)+q(1));
+    J(1,0) =   L1 * cos(q(0)+q(1))+L0*cos(q(0));
+    J(1,1) =   L1 * cos(q(0)+q(1));
+    J(5,0) = J(5,1) = 1;
+    return J;
+}
+
+JntArray diff(const JntArray& q,const JntArray& qdot,const double& dt)
+{
+    JntArray q_qdqt(q);
+    for(int i=0; i<q.rows(); i++)
+        q_qdqt(i) += dt*qdot(i);
+    return q_qdqt;
+}
+
+void random(JntArray& q)
+{
+    for(int i=0; i<q.rows(); i++)
+        random(q(i));
+}
+
+double compare_Jdot_Diff_vs_Solver(const Chain& chain,const double& dt,const unsigned int& representation,bool verbose)
+{
+    // This test verifies if the solvers gives approx. the same result as [ J(q+qdot*dot) - J(q) ]/dot
+    JntArray q(chain.getNrOfJoints());
+    JntArray qdot(chain.getNrOfJoints());
+    JntArray q_dqdt(chain.getNrOfJoints());
+
+
+    random(q);
+    random(qdot);
+    q_dqdt = diff(q,qdot,dt);
+    
+    ChainJntToJacDotSolver jdot_solver(chain);
+    ChainJntToJacSolver j_solver(chain);
+    ChainFkSolverPos_recursive fk_solver(chain);
+
+    Frame F_bs_ee_q,F_bs_ee_q_dqdt;
+    Jacobian jac_q(chain.getNrOfJoints()),
+                jac_q_dqdt(chain.getNrOfJoints()),
+                jdot_by_diff(chain.getNrOfJoints());
+                
+    j_solver.JntToJac(q,jac_q);
+    j_solver.JntToJac(q_dqdt,jac_q_dqdt);  
+    
+    fk_solver.JntToCart(q,F_bs_ee_q);
+    fk_solver.JntToCart(q_dqdt,F_bs_ee_q_dqdt);
+    
+    changeRepresentation(jac_q,F_bs_ee_q,representation);
+    changeRepresentation(jac_q_dqdt,F_bs_ee_q_dqdt,representation);
+    
+    Jdot_diff(jac_q,jac_q_dqdt,dt,jdot_by_diff);
+
+    Jacobian jdot_by_solver(chain.getNrOfJoints());
+    jdot_solver.setRepresentation(representation);
+    jdot_solver.JntToJacDot(JntArrayVel(q_dqdt,qdot),jdot_by_solver);
+
+    Twist jdot_qdot_by_solver;
+    MultiplyJacobian(jdot_by_solver,qdot,jdot_qdot_by_solver);
+
+    Twist jdot_qdot_by_diff;
+    MultiplyJacobian(jdot_by_diff,qdot,jdot_qdot_by_diff);
+    
+    if(verbose){
+        std::cout << "Jdot diff : \n" << jdot_by_diff<<std::endl;
+        std::cout << "Jdot solver:\n"<<jdot_by_solver<<std::endl;
+        
+        std::cout << "Error : " <<jdot_qdot_by_diff-jdot_qdot_by_solver<<q<<qdot<<std::endl;
+    }
+    double err = jdot_qdot_by_diff.vel.Norm() - jdot_qdot_by_solver.vel.Norm()
+                  + jdot_qdot_by_diff.rot.Norm() - jdot_qdot_by_solver.rot.Norm();
+    return std::abs(err);
+}
+
+double compare_d2_Jdot_Symbolic_vs_Solver(bool verbose)
+{
+    Chain chain=d2();
+    JntArray q(chain.getNrOfJoints());
+    JntArray qdot(chain.getNrOfJoints());
+
+    random(q);
+    random(qdot);
+    
+    ChainJntToJacDotSolver jdot_solver(chain);
+               
+    Jacobian jdot_sym = Jdot_d2_symbolic(q,qdot);
+
+    Jacobian jdot_by_solver(chain.getNrOfJoints());
+    jdot_solver.JntToJacDot(JntArrayVel(q,qdot),jdot_by_solver);
+
+    Twist jdot_qdot_by_solver;
+    MultiplyJacobian(jdot_by_solver,qdot,jdot_qdot_by_solver);
+
+    Twist jdot_qdot_sym;
+    MultiplyJacobian(jdot_sym,qdot,jdot_qdot_sym);
+    
+    if(verbose){
+        std::cout << "Jdot symbolic : \n" << jdot_sym<<std::endl;
+        std::cout << "Jdot solver:\n"<<jdot_by_solver<<std::endl;
+        std::cout << "Error : " <<jdot_qdot_sym-jdot_qdot_by_solver<<q<<qdot<<std::endl;
+    }
+    double err = jdot_qdot_sym.vel.Norm() - jdot_qdot_by_solver.vel.Norm()
+                  + jdot_qdot_sym.rot.Norm() - jdot_qdot_by_solver.rot.Norm();
+    return std::abs(err);    
+}
+
+bool runTest(const Chain& chain,const unsigned int& representation)
+{
+    bool success=true;
+    bool verbose = false;
+    double err;
+    bool print_err = true;
+    
+    for(double dt=1e-6;dt<0.1;dt*=10)
+    {
+            
+            double eps_diff_vs_solver = 3.0*dt; // Apparently :)
+
+            for(int i=0;i<100;i++)
+            {
+                err = compare_Jdot_Diff_vs_Solver(chain,dt,representation,verbose);
+
+                success &= err<=eps_diff_vs_solver;
+                
+                if(!success || print_err){
+                    std::cout<<" dt:"<< dt<<" err:"<<err
+                    <<" eps_diff_vs_solver:"<<eps_diff_vs_solver
+                    <<std::endl;
+                    if(!success)
+                        break;
+                }
+                    
+            }
+    }
+
+    return success;
+}
+
+void JacobianDotTest::testD2DiffHybrid(){
+    CPPUNIT_ASSERT(runTest(d2(),ChainJntToJacDotSolver::HYBRID));
+}
+void JacobianDotTest::testD6DiffHybrid(){
+    CPPUNIT_ASSERT(runTest(d6(),ChainJntToJacDotSolver::HYBRID));
+}
+void JacobianDotTest::testKukaDiffHybrid(){
+    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),ChainJntToJacDotSolver::HYBRID));
+}
+
+void JacobianDotTest::testD2DiffInertial(){
+    CPPUNIT_ASSERT(runTest(d2(),ChainJntToJacDotSolver::INTERTIAL));
+}
+void JacobianDotTest::testD6DiffInertial(){
+    CPPUNIT_ASSERT(runTest(d6(),ChainJntToJacDotSolver::INTERTIAL));
+}
+void JacobianDotTest::testKukaDiffInertial(){
+    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),ChainJntToJacDotSolver::INTERTIAL));
+}
+void JacobianDotTest::testD2DiffBodyFixed(){
+    CPPUNIT_ASSERT(runTest(d2(),ChainJntToJacDotSolver::BODYFIXED));
+}
+void JacobianDotTest::testD6DiffBodyFixed(){
+    CPPUNIT_ASSERT(runTest(d6(),ChainJntToJacDotSolver::BODYFIXED));
+}
+void JacobianDotTest::testKukaDiffBodyFixed(){
+    CPPUNIT_ASSERT(runTest(KukaLWR_DHnew(),ChainJntToJacDotSolver::BODYFIXED));
+}
+
+void JacobianDotTest::testD2Symbolic(){
+    // This test verifies if the solvers gives the same result as the symbolic Jdot (Hybrid only)
+    bool success=true;
+    bool verbose = false;
+    double err_d2_sym;
+    bool print_err = true;
+    
+    double eps_sym_vs_solver = 1e-10;
+    
+    for(int i=0;i<100;i++)
+    {
+        err_d2_sym =    compare_d2_Jdot_Symbolic_vs_Solver(verbose);
+        
+        success &= err_d2_sym<=eps_sym_vs_solver;
+        
+        if(!success || print_err){
+            std::cout <<" err_d2_sym:"<<err_d2_sym
+            <<" eps_sym_vs_solver:"<<eps_sym_vs_solver<<std::endl;
+            if(!success)
+            break;
+        }
+            
+    }
+    
+    CPPUNIT_ASSERT(success);
+}

--- a/orocos_kdl/tests/jacobiandottest.hpp
+++ b/orocos_kdl/tests/jacobiandottest.hpp
@@ -1,0 +1,49 @@
+#ifndef JACOBIANDOT_TEST_HPP
+#define JACOBIANDOT_TEST_HPP
+
+#include <cppunit/extensions/HelperMacros.h>
+#include <chainjnttojacdotsolver.hpp>
+#include <frames_io.hpp>
+#include <kinfam_io.hpp>
+
+class JacobianDotTest : public CppUnit::TestFixture
+{
+    CPPUNIT_TEST_SUITE( JacobianDotTest);
+    CPPUNIT_TEST(testD2DiffHybrid);
+    CPPUNIT_TEST(testD6DiffHybrid);
+    CPPUNIT_TEST(testKukaDiffHybrid);
+    
+    CPPUNIT_TEST(testD2DiffInertial);
+    CPPUNIT_TEST(testD6DiffInertial);
+    CPPUNIT_TEST(testKukaDiffInertial);
+    
+    CPPUNIT_TEST(testD2DiffBodyFixed);
+    CPPUNIT_TEST(testD6DiffBodyFixed);
+    CPPUNIT_TEST(testKukaDiffBodyFixed);
+    
+    CPPUNIT_TEST(testD2Symbolic);
+
+    CPPUNIT_TEST_SUITE_END();
+
+public:
+    void setUp();
+    void tearDown();
+
+    void testD2DiffHybrid();
+    void testD6DiffHybrid();
+    void testKukaDiffHybrid();
+
+    void testD2DiffInertial();
+    void testD6DiffInertial();
+    void testKukaDiffInertial();
+    
+    void testD2DiffBodyFixed();
+    void testD6DiffBodyFixed();
+    void testKukaDiffBodyFixed();
+    
+    void testD2Symbolic();
+private:
+    bool runTest(const Chain& chain,const unsigned int& representation);
+};
+
+#endif

--- a/orocos_kdl/tests/jacobiandottest.hpp
+++ b/orocos_kdl/tests/jacobiandottest.hpp
@@ -2,9 +2,9 @@
 #define JACOBIANDOT_TEST_HPP
 
 #include <cppunit/extensions/HelperMacros.h>
-#include <chainjnttojacdotsolver.hpp>
-#include <frames_io.hpp>
-#include <kinfam_io.hpp>
+#include "chainjnttojacdotsolver.hpp"
+#include "frames_io.hpp"
+#include "kinfam_io.hpp"
 
 class JacobianDotTest : public CppUnit::TestFixture
 {
@@ -42,8 +42,6 @@ public:
     void testKukaDiffBodyFixed();
     
     void testD2Symbolic();
-private:
-    bool runTest(const Chain& chain,const unsigned int& representation);
 };
 
 #endif


### PR DESCRIPTION
This PR adds the chainjnttojacdot solver that computes **Jdot**, a useful feature for calculating the cartesian acceleration : 
```
Xdot = J.qdot
Xddot = Jdot.qdot + J.qddot
```
It's an implementation of this paper : 
```
Symbolic differentiation of the velocity mapping for a serial kinematic chain
H. Bruyninckx, J. De Schutter
```
> http://www.sciencedirect.com/science/article/pii/0094114X9500069B

It supports the 3 representations : 
* **Body-fixed** : The reference frame is the end effector frame, and its origin is the velocity reference point.
* **Inertial** : The base is the reference frame, and its origin is the instantaneous velocity reference point.
* **Hybrid (*default*)**: The base is the reference frame, and the origin of the end effector frame is the velocity reference point (this is the default representation in KDL for the Jacobian).

Just call : 
```cpp
ChainJntToJacDotSolver jdot_solver(chain);

jdot_solver.setRepresentation( ChainJntToJacDotSolver::HYBRID ); //default
jdot_solver.setRepresentation( ChainJntToJacDotSolver::BODYFIXED );
jdot_solver.setRepresentation( ChainJntToJacDotSolver::INERTIAL );
// Hybrid is the default, so there's no need to call it 
jdot.JntToJacDot(q_in, jdot_out);

```

I also added a few tests : 
- A simple 2DOF arm for which I compute Jdot and compare it with the symbolic Jdot, for random q and qdot (in the hybrid representation) : error is <1e-10.
- 3 others arms for which I compute Jdot in the 3 representations, and compare it with [ J(q + qdot*dt) - J(q) ] / dt (which is , btw, not [that bad] (https://github.com/ahoarau/orocos_kinematics_dynamics/blob/feature/jdot_solver/orocos_kdl/tests/jacobiandottest.cpp#L255) :))

>> Featherstone's methods are (way) more efficient, but for a small chain (2x7dof) it's still pretty fast.