### PR TITLE
Make orocos_kdl installspace relocatable.

### DIFF
--- a/orocos_kdl/KDLConfig.cmake.in
+++ b/orocos_kdl/KDLConfig.cmake.in
@@ -5,14 +5,13 @@
 #  orocos_kdl_PKGCONFIG_DIR - directory containing the .pc pkgconfig files
 
 # Compute paths
-get_filename_component(SELF_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(orocos_kdl_INCLUDE_DIRS "@KDL_INCLUDE_DIRS@;@CMAKE_INSTALL_PREFIX@/include")
+set(orocos_kdl_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/../../include;@Boost_INCLUDE_DIRS@;@Eigen_INCLUDE_DIR@")
 
 if(NOT TARGET orocos-kdl)
-  include("${SELF_DIR}/OrocosKDLTargets.cmake")
+  include("${CMAKE_CURRENT_LIST_DIR}/OrocosKDLTargets.cmake")
 endif()
 
 set(orocos_kdl_LIBRARIES orocos-kdl)
 
 # where the .pc pkgconfig files are installed
-set(orocos_kdl_PKGCONFIG_DIR "@CMAKE_INSTALL_PREFIX@/lib/pkgconfig")
+set(orocos_kdl_PKGCONFIG_DIR "${CMAKE_CURRENT_LIST_DIR}/../../lib/pkgconfig")


### PR DESCRIPTION
Making the include paths relative to the find module makes it possible to move the installspace around after creation, including building it in conjunction with packages which depend on it, where the DESTDIR variable is set.