### PR TITLE
orocos_kdl: Support getting eps from WDLS velocity solver

### DIFF
--- a/orocos_kdl/src/chainiksolvervel_wdls.hpp
+++ b/orocos_kdl/src/chainiksolvervel_wdls.hpp
@@ -180,6 +180,11 @@ namespace KDL
         double getSigmaMin()const {return sigmaMin;};
 
         /**
+         * Request the value of eps
+         */
+        double getEps()const {return eps;};
+
+        /**
          * Request the value of lambda for the minimum
          */
         double getLambda()const {return lambda;};


### PR DESCRIPTION
Ensures that all relevant parameters are exposed.