### PR TITLE
support for Visual Studio 2015 C++ compiler

### DIFF
--- a/orocos_kdl/src/velocityprofile_traphalf.cpp
+++ b/orocos_kdl/src/velocityprofile_traphalf.cpp
@@ -42,6 +42,7 @@
 
 //#include "error.h"
 #include "velocityprofile_traphalf.hpp"
+#include <algorithm>
 
 namespace KDL {
 


### PR DESCRIPTION
This additional header was required to allow compilation with Visual Studio 2015 on Windows 7