### PR TITLE
Enable RPATH for OSX for cmake >= 2.8.12 by default

### DIFF
--- a/orocos_kdl/src/CMakeLists.txt
+++ b/orocos_kdl/src/CMakeLists.txt
@@ -68,7 +68,7 @@ ENDIF()
 IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
     IF(NOT MSVC)
         #add the option to disable RPATH
-        OPTION(OROCOSKDL_ENABLE_RPATH "Enable RPATH during installation" FALSE)
+        OPTION(OROCOSKDL_ENABLE_RPATH "Enable RPATH during installation" TRUE)
         MARK_AS_ADVANCED(OROCOSKDL_ENABLE_RPATH)
     ENDIF(NOT MSVC)
 


### PR DESCRIPTION
Set the default to enable RPATH settings. This should only affect OSX builds that typically require this.