### PR TITLE
kdl: added get sigma function to wdls solver

### DIFF
--- a/orocos_kdl/src/chainiksolvervel_wdls.cpp
+++ b/orocos_kdl/src/chainiksolvervel_wdls.cpp
@@ -85,9 +85,12 @@ namespace KDL
         maxiter=maxiter_in;
     }
 
-    void ChainIkSolverVel_wdls::getSigma(Eigen::VectorXd& Sout)
+    int ChainIkSolverVel_wdls::getSigma(Eigen::VectorXd& Sout)
     {
+        if (Sout.size() != S.size())
+            return (error = E_SIZE_MISMATCH);
         Sout=S;
+        return (error = E_NOERROR);
     }
 
     int ChainIkSolverVel_wdls::CartToJnt(const JntArray& q_in, const Twist& v_in, JntArray& qdot_out)

--- a/orocos_kdl/src/chainiksolvervel_wdls.cpp
+++ b/orocos_kdl/src/chainiksolvervel_wdls.cpp
@@ -85,6 +85,11 @@ namespace KDL
         maxiter=maxiter_in;
     }
 
+    void ChainIkSolverVel_wdls::getSigma(Eigen::VectorXd& Sout)
+    {
+        Sout=S;
+    }
+
     int ChainIkSolverVel_wdls::CartToJnt(const JntArray& q_in, const Twist& v_in, JntArray& qdot_out)
     {
         if(nj != q_in.rows() || nj != qdot_out.rows())

--- a/orocos_kdl/src/chainiksolvervel_wdls.hpp
+++ b/orocos_kdl/src/chainiksolvervel_wdls.hpp
@@ -185,7 +185,7 @@ namespace KDL
         /**
          * Request the six singular values of the Jacobian
          */
-        void getSigma(Eigen::VectorXd& Sout);
+        int getSigma(Eigen::VectorXd& Sout);
 
         /**
          * Request the value of eps

--- a/orocos_kdl/src/chainiksolvervel_wdls.hpp
+++ b/orocos_kdl/src/chainiksolvervel_wdls.hpp
@@ -183,6 +183,11 @@ namespace KDL
         double getSigmaMin()const {return sigmaMin;};
 
         /**
+         * Request the six singular values of the Jacobian
+         */
+        void getSigma(Eigen::VectorXd& Sout);
+
+        /**
          * Request the value of eps
          */
         double getEps()const {return eps;};


### PR DESCRIPTION
Adding a function to read the singular values, sigma, so that the manipulability can be calculated from the product.