### PR TITLE
Fix some singularities when using Rotation::GetRotAngle()

### DIFF
--- a/orocos_kdl/CMakeLists.txt
+++ b/orocos_kdl/CMakeLists.txt
@@ -74,7 +74,7 @@ endif(KDL_USE_NEW_TREE_INTERFACE)
 
 INCLUDE (${PROJ_SOURCE_DIR}/config/DependentOption.cmake)
 
-OPTION(ENABLE_TESTS OFF "Enable building of tests")
+OPTION(ENABLE_TESTS ON "Enable building of tests")
 IF( ENABLE_TESTS )
   # If not in standard paths, set CMAKE_xxx_PATH's in environment, eg.
   # export CMAKE_INCLUDE_PATH=/opt/local/include

--- a/orocos_kdl/CMakeLists.txt
+++ b/orocos_kdl/CMakeLists.txt
@@ -74,7 +74,7 @@ endif(KDL_USE_NEW_TREE_INTERFACE)
 
 INCLUDE (${PROJ_SOURCE_DIR}/config/DependentOption.cmake)
 
-OPTION(ENABLE_TESTS ON "Enable building of tests")
+OPTION(ENABLE_TESTS OFF "Enable building of tests")
 IF( ENABLE_TESTS )
   # If not in standard paths, set CMAKE_xxx_PATH's in environment, eg.
   # export CMAKE_INCLUDE_PATH=/opt/local/include

--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -370,6 +370,7 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
             && (std::abs(data[0] + data[4] + data[8]-3) < epsilon2))
         {
             // this singularity is identity matrix so angle = 0, axis is arbitrary
+            // Choose 0, 0, 1 to pass orocos tests
             axis = KDL::Vector(0,0,1);
             angle = 0.0;
             return angle;

--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -370,7 +370,7 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
             && (std::abs(data[0] + data[4] + data[8]-3) < epsilon2))
         {
             // this singularity is identity matrix so angle = 0, axis is arbitrary
-            axis = KDL::Vector(1,0,0);
+            axis = KDL::Vector(0,0,1);
             angle = 0.0;
             return angle;
         }

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -375,8 +375,8 @@ void FramesTest::TestRotation() {
 
 	TestOneRotation("rot([1,1,0],180)", KDL::Rotation::Rot(KDL::Vector(1,1,0),180*deg2rad), 180*deg2rad, Vector(1,1,0)/sqrt(2.0));
 	// opposite of +180
-	TestOneRotation("rot([1,1,0],-180)", KDL::Rotation::Rot(KDL::Vector(1,1,0),-180*deg2rad), 180*deg2rad, -Vector(1,1,0)/sqrt(2.0));
-	TestOneRotation("rot([-1,-1,0],180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,0),180*deg2rad), 180*deg2rad, -Vector(1,1,0)/sqrt(2.0));
+	TestOneRotation("rot([1,1,0],-180)", KDL::Rotation::Rot(KDL::Vector(1,1,0),-180*deg2rad), 180*deg2rad, Vector(1,1,0)/sqrt(2.0));
+	TestOneRotation("rot([-1,-1,0],180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,0),180*deg2rad), 180*deg2rad, Vector(1,1,0)/sqrt(2.0));
 	// opposite of +180
 	TestOneRotation("rot([-1,-1,0],-180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,0),-180*deg2rad), 180*deg2rad, Vector(1,1,0)/sqrt(2.0));
 


### PR DESCRIPTION

Using:
```python
import PyKDL as kdl

r = kdl.Rotation.RPY(3.14179265359, 1.57099632679, 0.0002)
print r
print "-"*30

axis_angle = r.GetRot()
a = axis_angle.Norm()
v = axis_angle / a

r2 = kdl.Rotation.Rot(v, a)
print r2
```
Results in two different rotations matrices. 
```
r =[     -0.0002,  3.7932e-12,          -1;
       -4e-08,          -1,  4.2068e-12;
           -1,       4e-08,      0.0002]
r2 = [     -0.0002,  2.5807e-08,           1;
   2.5807e-08,          -1, 2.58121e-08;
            1, 2.58121e-08,      0.0002]
```

similarly, `kdl.Rotation.RPY(-0.0002, 1.57059632679, 3.14139265359)`  Does not work. 

The new implementation is taken from:
http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/index.htm
