### PR TITLE
Trivial typo fixes

### DIFF
--- a/orocos_kdl/config/FindEigen3.cmake
+++ b/orocos_kdl/config/FindEigen3.cmake
@@ -11,7 +11,7 @@
 #  EIGEN3_VERSION - eigen version
 #
 # This module reads hints about search locations from 
-# the following enviroment variables:
+# the following environment variables:
 #
 # EIGEN3_ROOT
 # EIGEN3_ROOT_DIR

--- a/orocos_kdl/doc/tests.txt
+++ b/orocos_kdl/doc/tests.txt
@@ -51,7 +51,7 @@ serialchaintest.cpp :
         - TestCartVelAndJac
                 checks whether jnt2cartvel and jnt2jac are consistent.
         - TestCartVelAndInverse
-                checks wether jnt2cartvel and cartvel2jnt are consistent.
+                checks whether jnt2cartvel and cartvel2jnt are consistent.
 
     - These routines are used on :
             - SerialChain 

--- a/orocos_kdl/doc/tex/UserManual.tex
+++ b/orocos_kdl/doc/tex/UserManual.tex
@@ -40,7 +40,7 @@ Kinematics \& Dynamics Library is a c++ library that offers
 \section{Getting Orocos KDL}
 \label{sec:getting-orocos-kdl}
 
-First off all you need to succesfully install the KDL-library. This is
+First off all you need to successfully install the KDL-library. This is
 explained in the \textbf{Installation Manual}, it can be found on
 \url{http://www.orocos.org/kdl/Installation_Manual}
 

--- a/orocos_kdl/examples/geometry.cpp
+++ b/orocos_kdl/examples/geometry.cpp
@@ -74,13 +74,13 @@ int main()
     //Default constructor
     KDL::Rotation r1;
     //Creating a rotation matrix out of three unit vectors Vx, Vy,
-    //Vz. Be carefull, these vectors should be normalised and
+    //Vz. Be careful, these vectors should be normalised and
     //orthogonal. Otherwise this can result in an inconsistent
     //rotation matrix
     KDL::Rotation r2(KDL::Vector(0,0,1),
                      KDL::Vector(0,-1,0),
                      KDL::Vector(-1,0,0));
-    //Creating a rotation matrix out of 9 values, Be carefull, these
+    //Creating a rotation matrix out of 9 values, Be careful, these
     //values can result in an inconsisten rotation matrix if the
     //resulting rows/columns are not orthogonal/normalized
     KDL::Rotation r3(0,0,-1,1,0,0,0,-1,0);

--- a/orocos_kdl/src/chainidsolver_vereshchagin.cpp
+++ b/orocos_kdl/src/chainidsolver_vereshchagin.cpp
@@ -220,7 +220,7 @@ void ChainIdSolver_Vereshchagin::downwards_sweep(const Jacobian& alfa, const Jnt
             s.PC = s.P * s.C;
 
             //u=(Q-Z(R+PC)=sum of external forces along the joint axes,
-            //R are the forces comming from the children,
+            //R are the forces coming from the children,
             //Q is taken zero (do we need to take the previous calculated torques?
 
             //projection of coriolis and centrepital forces into joint subspace (0 0 Z)
@@ -388,7 +388,7 @@ void ChainIdSolver_Vereshchagin::getJointBiasAcceleration(JntArray& bias_q_dotdo
     {
         //this is only force
         double tmp = results[i + 1].totalBias;
-        //this is accelleration
+        //this is acceleration
         bias_q_dotdot(i) = tmp / results[i + 1].D;
 
         //s.totalBias = - dot(s.Z, s.R + s.PC);

--- a/orocos_kdl/src/chainiksolverpos_lma.hpp
+++ b/orocos_kdl/src/chainiksolverpos_lma.hpp
@@ -75,7 +75,7 @@ public:
     /**
 	 * \brief constructs an ChainIkSolverPos_LMA solver.
 	 *
-	 * The default parameters are choosen to be applicable to industrial-size robots
+	 * The default parameters are chosen to be applicable to industrial-size robots
 	 * (e.g. 0.5 to 3 meters range in task space), with an accuracy that is more then
 	 * sufficient for typical industrial applications.
 	 *

--- a/orocos_kdl/src/frameacc.hpp
+++ b/orocos_kdl/src/frameacc.hpp
@@ -4,7 +4,7 @@
  *      Rall Algebra of (subset of) the classes defined in frames,
  *      i.e. classes that contain a set (value,derivative,2nd derivative)
  *      and define operations on that set
- *      this classes are usefull for automatic differentiation ( <-> symbolic diff ,
+ *      this classes are useful for automatic differentiation ( <-> symbolic diff ,
  *      <-> numeric diff).
  *      Defines VectorAcc, RotationAcc, FrameAcc, doubleAcc.
  *      Look at the corresponding classes Vector Rotation Frame Twist and

--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -341,10 +341,10 @@ Vector Rotation::GetRot() const
 
 /** Returns the rotation angle around the equiv. axis
  * @param axis the rotation axis is returned in this variable
- * @param eps :  in the case of angle == 0 : rot axis is undefined and choosen
+ * @param eps :  in the case of angle == 0 : rot axis is undefined and chosen
  *                                         to be the Z-axis
  *               in the case of angle == PI : 2 solutions, positive Z-component
- *                                            of the axis is choosen.
+ *                                            of the axis is chosen.
  * @result returns the rotation angle (between [0..PI] )
  * /todo :
  *   Check corresponding routines in rframes and rrframes

--- a/orocos_kdl/src/frames.hpp
+++ b/orocos_kdl/src/frames.hpp
@@ -378,10 +378,10 @@ public:
 
 	/** Returns the rotation angle around the equiv. axis
 	 * @param axis the rotation axis is returned in this variable
-	 * @param eps :  in the case of angle == 0 : rot axis is undefined and choosen
+	 * @param eps :  in the case of angle == 0 : rot axis is undefined and chosen
 	 *                                         to be +/- Z-axis
 	 *               in the case of angle == PI : 2 solutions, positive Z-component
-	 *                                            of the axis is choosen.
+	 *                                            of the axis is chosen.
 	 * @result returns the rotation angle (between [0..PI] )
 	 */
 	double GetRotAngle(Vector& axis,double eps=epsilon) const;

--- a/orocos_kdl/src/framevel.hpp
+++ b/orocos_kdl/src/framevel.hpp
@@ -3,7 +3,7 @@
  *      This file contains the definition of classes for a
  *      Rall Algebra of (subset of) the classes defined in frames,
  *      i.e. classes that contain a pair (value,derivative) and define operations on that pair
- *      this classes are usefull for automatic differentiation ( <-> symbolic diff , <-> numeric diff)
+ *      this classes are useful for automatic differentiation ( <-> symbolic diff , <-> numeric diff)
  *      Defines VectorVel, RotationVel, FrameVel.  Look at Frames.h for details on how to work
  *      with Frame objects.
  *  \author

--- a/orocos_kdl/src/rotational_interpolation_sa.hpp
+++ b/orocos_kdl/src/rotational_interpolation_sa.hpp
@@ -56,7 +56,7 @@ namespace KDL {
 	  * An interpolation algorithm which rotates a frame over the existing
 	  * single rotation axis
 	  * formed by start and end rotation. If more than one rotational axis
-	  * exist, an arbitrary one will be choosen, therefore it is not recommended 
+	  * exist, an arbitrary one will be chosen, therefore it is not recommended 
 	  * to try to interpolate a 180 degrees rotation.
 	  * @ingroup Motion
 	  */

--- a/orocos_kdl/src/trajectory.hpp
+++ b/orocos_kdl/src/trajectory.hpp
@@ -40,7 +40,7 @@
  *		$Id: trajectory.h,v 1.1.1.1.2.5 2003/07/23 16:44:25 psoetens Exp $
  *		$Name:  $
  *  \todo
- *     Peter's remark : should seperate I/O from other routines in the
+ *     Peter's remark : should separate I/O from other routines in the
  *     motion/chain directories
  *     The problem is that the I/O uses virtual inheritance to write
  *     the trajectories/geometries/velocityprofiles/...

--- a/orocos_kdl/src/tree.hpp
+++ b/orocos_kdl/src/tree.hpp
@@ -39,7 +39,7 @@ namespace KDL
     class TreeElement;
 
 #ifdef KDL_USE_NEW_TREE_INTERFACE
-    //We use smart pointers for managing tree nodes for now becuase
+    //We use smart pointers for managing tree nodes for now because
     //c++11 and unique_ptr support is not ubiquitous
     typedef boost::shared_ptr<TreeElement> TreeElementPtr;
     typedef boost::shared_ptr<const TreeElement> TreeElementConstPtr;

--- a/orocos_kdl/src/utilities/error.h
+++ b/orocos_kdl/src/utilities/error.h
@@ -56,7 +56,7 @@ namespace KDL {
 class Error {
 public:
     /** Returns a description string describing the error.
-     *  the returned pointer only garanteed to exists as long as 
+     *  the returned pointer only guaranteed to exists as long as 
      * the Error object exists.
      */
 	virtual ~Error() {}
@@ -129,7 +129,7 @@ public:
     virtual const char* Description() const {return "Unexpected identifier, expecting TRANS or ROT";}
     virtual int GetType() const {return 201;}
 };
-//! Error_Redundancy indicates an error that occured during solving for redundancy.
+//! Error_Redundancy indicates an error that occurred during solving for redundancy.
 class Error_RedundancyIO:public Error_IO  {};
 class Error_Redundancy_Illegal_Resolutiontype : public Error_RedundancyIO {
 public:

--- a/orocos_kdl/src/utilities/error_stack.h
+++ b/orocos_kdl/src/utilities/error_stack.h
@@ -33,7 +33,7 @@
  *      ORO_Geometry V0.2
  *   
  * \par history
- *   - changed layout of the comments to accomodate doxygen
+ *   - changed layout of the comments to accommodate doxygen
  */
 #ifndef ERROR_STACK_H
 #define ERROR_STACK_H

--- a/orocos_kdl/src/utilities/rall1d.h
+++ b/orocos_kdl/src/utilities/rall1d.h
@@ -37,7 +37,7 @@ namespace KDL {
  *  -   S defines a scalar type that can operate on Rall1d.  This is the type that 
  *      is used to give back values of Norm() etc. 
  *
- * S is usefull when you recurse a Rall1d object into itself to create a 2nd, 3th, 4th,.. 
+ * S is useful when you recurse a Rall1d object into itself to create a 2nd, 3rd, 4th,.. 
  * derivatives. (e.g. Rall1d< Rall1d<double>, Rall1d<double>, double> ).
  *
  * S is always passed by value. 

--- a/orocos_kdl/src/utilities/rall2d.h
+++ b/orocos_kdl/src/utilities/rall2d.h
@@ -42,7 +42,7 @@ namespace KDL {
  *  -   S defines a scalar type that can operate on Rall1d.  This is the type that 
  *      is used to give back values of Norm() etc. 
  *
- * S is usefull when you recurse a Rall1d object into itself to create a 2nd, 3th, 4th,.. 
+ * S is useful when you recurse a Rall1d object into itself to create a 2nd, 3rd, 4th,.. 
  * derivatives. (e.g. Rall1d< Rall1d<double>, Rall1d<double>, double> ).
  *
  * S is always passed by value. 

--- a/orocos_kdl/src/utilities/utility.cxx
+++ b/orocos_kdl/src/utilities/utility.cxx
@@ -4,7 +4,7 @@
  *      ORO_Geometry V0.2
  *   
  *  @par history
- *   - changed layout of the comments to accomodate doxygen
+ *   - changed layout of the comments to accommodate doxygen
  */
  
 #include "utility.h"

--- a/orocos_kdl/src/utilities/utility.h
+++ b/orocos_kdl/src/utilities/utility.h
@@ -16,7 +16,7 @@
  *    functions and macro definitions.
  *  
  *  \par history
- *   - changed layout of the comments to accomodate doxygen
+ *   - changed layout of the comments to accommodate doxygen
  */
 
 

--- a/orocos_kdl/src/utilities/utility_io.cxx
+++ b/orocos_kdl/src/utilities/utility_io.cxx
@@ -104,7 +104,7 @@ int _EatSpace( std::istream& is,int* countp=NULL) {
 
 
 // Eats whites, returns, tabs and the delim character
-//  Checks wether delim char. is encountered.
+//  Checks whether delim char. is encountered.
 void Eat( std::istream& is, int delim )
 {   
     int ch;
@@ -117,7 +117,7 @@ void Eat( std::istream& is, int delim )
 }
 
 // Eats whites, returns, tabs and the delim character
-//  Checks wether delim char. is encountered.
+//  Checks whether delim char. is encountered.
 // EatEnd does not eat all space-like char's at the end.
 void EatEnd( std::istream& is, int delim )
 {   

--- a/orocos_kdl/src/velocityprofile_trap.hpp
+++ b/orocos_kdl/src/velocityprofile_trap.hpp
@@ -62,7 +62,7 @@ class VelocityProfile_Trap : public VelocityProfile
 		// For "running" a motion profile :
 		double a1,a2,a3; // coef. from ^0 -> ^2 of first part
 		double b1,b2,b3; // of 2nd part
-		double c1,c2,c3; // of 3th part
+		double c1,c2,c3; // of 3rd part
 		double duration;
 		double t1,t2;
 

--- a/orocos_kdl/src/velocityprofile_traphalf.hpp
+++ b/orocos_kdl/src/velocityprofile_traphalf.hpp
@@ -65,7 +65,7 @@ class VelocityProfile_TrapHalf : public VelocityProfile
 		// For "running" a motion profile :
 		double a1,a2,a3; // coef. from ^0 -> ^2 of first part
 		double b1,b2,b3; // of 2nd part
-		double c1,c2,c3; // of 3th part
+		double c1,c2,c3; // of 3rd part
 		double duration;
 		double t1,t2;
 

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -228,7 +228,7 @@ void FramesTest::TestEuler() {
 	TESTEULERZYX(0,0,0.3)
 	TESTEULERZYX(0,0,0)
 	TESTEULERZYX(0.3,0.999*M_PI/2,0.1)
-	// if beta== +/- M_PI/2 => multiple solutions available, gamma will be choosen to be zero !
+	// if beta== +/- M_PI/2 => multiple solutions available, gamma will be chosen to be zero !
 	// so we test with gamma==0 !
 	TESTEULERZYX(0.3,0.9999999999*M_PI/2,0)
 	TESTEULERZYX(0.3,0.99999999*M_PI/2,0)

--- a/orocos_kdl/tests/serialchaintest.cpp
+++ b/orocos_kdl/tests/serialchaintest.cpp
@@ -206,7 +206,7 @@ public:
     }
 
     int test(JointVector& q,JointVector& qdot) {
-        std::cout << "Testing wether Jnt2CartVel and Jnt2Jac are consistent " << std::endl;
+        std::cout << "Testing whether Jnt2CartVel and Jnt2Jac are consistent " << std::endl;
         std::cout << "q[1] = " << q[1] << std::endl;
         double deltaq = 1E-4;
         double epsJ   = 1E-4;
@@ -286,7 +286,7 @@ public:
     }
 
     int test(const JointVector& q,const JointVector& qdot) {
-        std::cout << "Testing wether Jnt2CartVel and CartVel2Jnt are consistent " << std::endl;
+        std::cout << "Testing whether Jnt2CartVel and CartVel2Jnt are consistent " << std::endl;
         double epsJ   = 1E-7;
 		int result;
 

--- a/python_orocos_kdl/cmake/FindSIP.cmake
+++ b/python_orocos_kdl/cmake/FindSIP.cmake
@@ -9,7 +9,7 @@
 # This file defines the following variables:
 #
 # SIP_VERSION - The version of SIP found expressed as a 6 digit hex number
-#     suitable for comparision as a string.
+#     suitable for comparison as a string.
 #
 # SIP_VERSION_STR - The version of SIP found as a human readable string.
 #

--- a/python_orocos_kdl/cmake/SIPMacros.cmake
+++ b/python_orocos_kdl/cmake/SIPMacros.cmake
@@ -61,7 +61,7 @@ MACRO(ADD_SIP_PYTHON_MODULE MODULE_NAME MODULE_SIP)
 
     # We give this target a long logical target name.
     # (This is to avoid having the library name clash with any already
-    # install library names. If that happens then cmake dependancy
+    # install library names. If that happens then cmake dependency
     # tracking get confused.)
     STRING(REPLACE "." "_" _logical_name ${MODULE_NAME})
     SET(_logical_name "python_module_${_logical_name}")


### PR DESCRIPTION
Most are non-user facing. Some are doxy. 
`codespell -d -q 3`was used to find typos