### PR TITLE
GetRot still seems to return NaNs for rotation matrices that contain a small error (not 100% orthogonal)

### DIFF
--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -29,6 +29,7 @@
 
 #define _USE_MATH_DEFINES  // For MSVC
 #include <math.h>
+#include <algorithm>
 
 namespace KDL {
 
@@ -439,7 +440,11 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
         return angle; // return 180 deg rotation
     }
 
-    angle = acos(( data[0] + data[4] + data[8] - 1)/2);
+    // If the matrix is slightly non-orthogonal, `f` may be out of the (-1, +1) range.
+    // Therefore, clamp it between those values to avoid NaNs.
+    double f = (data[0] + data[4] + data[8] - 1) / 2;
+    angle = acos(std::max(-1.0, std::min(1.0, f)));
+
     x = (data[7] - data[5]);
     y = (data[2] - data[6]);
     z = (data[3] - data[1]);

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -393,6 +393,19 @@ void FramesTest::TestRotation() {
 	TestOneRotation("rot([-1,-1,-1],180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,-1),180*deg2rad), 180*deg2rad, Vector(1,1,1)/sqrt(3.0));
 	// same as +180
 	TestOneRotation("rot([-1,-1,-1],-180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,-1),-180*deg2rad), 180*deg2rad, Vector(1,1,1)/sqrt(3.0));
+
+  // Test GetRotAngle on slightly non-orthogonal rotation matrices
+  {
+    Vector axis;
+    double angle = KDL::Rotation( 1, 0, 0 + 1e-6, 0, 1, 0, 0, 0,  1 + 1e-6).GetRotAngle(axis);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("rot(NON-ORTHOGONAL, 0)", 0.0, angle, epsilon);
+  }
+
+  {
+    Vector axis;
+    double angle = KDL::Rotation(-1, 0, 0 + 1e-6, 0, 1, 0, 0, 0, -1 - 1e-6).GetRotAngle(axis);
+    CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("rot(NON-ORTHOGONAL, PI)", M_PI, angle, epsilon);
+  }
 }
 
 void FramesTest::TestQuaternion() {


### PR DESCRIPTION
We came across that the new implementation of "GetRot" still returns NaN, if the rotatation matrix is slightly non orthogonal. While this is of course not a valid rotation matrix, a small margin of error should be allowed. 

```
import PyKDL as kdl

f1 = kdl.Frame(kdl.Rotation(0.00923097,    0.969766,   -0.243866, 0.999943,  -0.0102479, -0.00290165, -0.00531284,   -0.243825,   -0.969805), kdl.Vector(0.112752,     1.26141,    0.250001))

f2 = kdl.Frame(kdl.Rotation(0.00924127,    0.969765,   -0.243866, 0.999943,  -0.0102586,  -0.0029021, -0.00531613,   -0.243825,   -0.969805), kdl.Vector(0.112757,     1.26141,   -0.298506))

def orthogonalize(f):
    R, P, Y = f.M.GetRPY()
    return kdl.Frame(kdl.Rotation.RPY(R, P, Y), kdl.Vector(f.p.x(), f.p.y(), f.p.z()))

print kdl.diff(f1, f2)
print kdl.diff(orthogonalize(f1), orthogonalize(f2))
```