### PR TITLE
Add edge testcase for GetRotAngle

### DIFF
--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -393,6 +393,29 @@ void FramesTest::TestRotation() {
 	TestOneRotation("rot([-1,-1,-1],180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,-1),180*deg2rad), 180*deg2rad, Vector(1,1,1)/sqrt(3.0));
 	// same as +180
 	TestOneRotation("rot([-1,-1,-1],-180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,-1),-180*deg2rad), 180*deg2rad, Vector(1,1,1)/sqrt(3.0));
+
+	TestOneRotation("rot([0.707107, 0, 0.707107", KDL::Rotation::RPY(-2.9811968953315162, -atan(1)*2, -0.1603957582582825), 180*deg2rad, Vector(0.707107,0,0.707107) );
+}
+
+void FramesTest::TestGetRotAngle() {
+    static const double pi = atan(1)*4;
+    double roll = -2.9811968953315162;
+    double pitch = -pi/2;
+    double yaw = -0.1603957582582825;
+
+    // rpy -> rotation
+    KDL::Rotation kdlRotation1 = KDL::Rotation::RPY(roll, pitch, yaw);
+
+    // rotation -> angle-axis (with KDL::GetRotAngle)
+    KDL::Vector kdlAxis;
+    double theta = kdlRotation1.GetRotAngle(kdlAxis);
+
+
+    CPPUNIT_ASSERT(0==isnan(theta));
+    CPPUNIT_ASSERT(0==isnan(kdlAxis[0]));
+    CPPUNIT_ASSERT(0==isnan(kdlAxis[1]));
+    CPPUNIT_ASSERT(0==isnan(kdlAxis[2]));
+
 }
 
 void FramesTest::TestQuaternion() {

--- a/orocos_kdl/tests/framestest.hpp
+++ b/orocos_kdl/tests/framestest.hpp
@@ -19,6 +19,7 @@ class FramesTest : public CppUnit::TestFixture
     CPPUNIT_TEST(TestJntArray);
     CPPUNIT_TEST(TestRotationDiff);
     CPPUNIT_TEST(TestEuler);
+    CPPUNIT_TEST(TestGetRotAngle);
     CPPUNIT_TEST_SUITE_END();
 
 public:
@@ -35,6 +36,7 @@ public:
     void TestJntArrayWhenEmpty();
 	void TestRotationDiff();
 	void TestEuler();
+	void TestGetRotAngle();
 
 private:
     void TestVector2(Vector& v);


### PR DESCRIPTION
We had reports that this edge case for GetRotAngle would return NaNs, however we cannot reproduce this. I added the case to the unit tests.