### PR TITLE
Typos: doxygen

### DIFF
--- a/orocos_kdl/src/chain.hpp
+++ b/orocos_kdl/src/chain.hpp
@@ -28,7 +28,7 @@
 namespace KDL {
     /**
 	  * \brief This class encapsulates a <strong>serial</strong> kinematic
-	  * interconnection structure. It is build out of segments.
+	  * interconnection structure. It is built out of segments.
      *
      * @ingroup KinematicFamily
      */

--- a/orocos_kdl/src/chainiksolvervel_pinv_nso.cpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv_nso.cpp
@@ -134,7 +134,7 @@ namespace KDL
               tmp(i) = weights(i)*(q_in(i) - opt_pos(i)) / A;
           }
 
-          // Calcualte J^-1 * J * Jc^-1 = V*S^-1*U' * U*S*V' * tmp
+          // Calculate J^-1 * J * Jc^-1 = V*S^-1*U' * U*S*V' * tmp
           tmp2 = V * Sinv.asDiagonal() * U.transpose() * U * S.asDiagonal() * V.transpose() * tmp;
 
           for (i = 0; i < nj; ++i) {

--- a/orocos_kdl/src/tree.hpp
+++ b/orocos_kdl/src/tree.hpp
@@ -92,7 +92,7 @@ namespace KDL
 
     /**
      * \brief  This class encapsulates a <strong>tree</strong>
-     * kinematic interconnection structure. It is build out of segments.
+     * kinematic interconnection structure. It is built out of segments.
      *
      * @ingroup KinematicFamily
      */


### PR DESCRIPTION
trival grammar fixes found downstream (FreeCAD) using `codespell`