### PR TITLE
Fix __repr__ returns non string in Python 3

### DIFF
--- a/python_orocos_kdl/PyKDL/frames.sip
+++ b/python_orocos_kdl/PyKDL/frames.sip
@@ -60,12 +60,12 @@ public:
     (*sipCpp)(a0)=a1;
 %End
 
-    const char* __repr__() const;
+    const std::string* __repr__() const;
 %MethodCode
     std::ostringstream oss;
     oss<<(*sipCpp);
     std::string s(oss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
 
     void ReverseSign();
@@ -134,12 +134,12 @@ public:
     (*sipCpp)(i,j)=a1;
 %End
 
-    const char* __repr__() const;
+    const std::string* __repr__() const;
 %MethodCode
     std::ostringstream oss;
     oss<<(*sipCpp);
     std::string s(oss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
     
     void SetInverse();
@@ -238,12 +238,12 @@ public:
         (*sipCpp).M(i,j)=a1;
 %End
 
-    const char* __repr__() const;
+    const std::string* __repr__() const;
 %MethodCode
     std::ostringstream oss;
     oss<<(*sipCpp);
     std::string s(oss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
 
     Frame DH_Craig1989(double a,double alpha,double d,double theta);
@@ -311,12 +311,12 @@ public:
     (*sipCpp)(a0)=a1;
 %End
 
-    const char* __repr__() const;
+    const std::string* __repr__() const;
 %MethodCode
     std::ostringstream oss;
     oss<<(*sipCpp);
     std::string s(oss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
 
     static Twist Zero() /Factory/;
@@ -384,12 +384,12 @@ public:
     (*sipCpp)(a0)=a1;
 %End
 
-    const char* __repr__() const;
+    const std::string* __repr__() const;
 %MethodCode
     std::ostringstream oss;
     oss<<(*sipCpp);
     std::string s(oss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
 
     static Wrench Zero() /Factory/;

--- a/python_orocos_kdl/PyKDL/kinfam.sip
+++ b/python_orocos_kdl/PyKDL/kinfam.sip
@@ -49,12 +49,12 @@ public:
 
     JointType getType() const;
     std::string getTypeName() const;
-    const char* __repr__();
+    const std::string* __repr__();
     %MethodCode
         std::ostringstream oss;
         oss<<(*sipCpp);
         std::string s(oss.str());
-        sipRes=s.c_str();
+        sipRes=&s;
     %End
 };
 
@@ -109,12 +109,12 @@ public:
     Segment(const Joint& joint=Joint(Joint::None), const Frame& f_tip=Frame::Identity(),const RigidBodyInertia& I = RigidBodyInertia::Zero());
     Segment(const Segment& in);
 
-    const char* __repr__();
+    const std::string* __repr__();
 %MethodCode
     std::stringstream ss;
     ss<<(*sipCpp);
     std::string s(ss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
     
     const Frame& getFrameToTip()const /Factory/;
@@ -198,12 +198,12 @@ public:
     (*sipCpp)(a0)=a1;
 %End
 
-    const char* __repr__();
+    const std::string* __repr__();
 %MethodCode
     std::stringstream ss;
     ss<<sipCpp->data;
     std::string s(ss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
 };
 
@@ -282,12 +282,12 @@ public:
     (*sipCpp)(i,j)=a1;
 %End
 
-    const char* __repr__();
+    const std::string* __repr__();
 %MethodCode
     std::stringstream ss;
     ss<<sipCpp->data;
     std::string s(ss.str());
-    sipRes=s.c_str();
+    sipRes=&s;
 %End
     Twist getColumn(unsigned int i) const /Factory/;
     void setColumn(unsigned int i,const Twist& t);


### PR DESCRIPTION
When built with Python 3, print Vector/Rotation/Frame returns __repr__ returns non string error.  
Fixed by replacing const char* with const std::string*. The fix has been tested to be backward compatible with Python 2