### PR TITLE
Added q_min and q_max size mismatch check in ChainIkSolverPos_NR_JL

### DIFF
--- a/orocos_kdl/src/chainiksolverpos_nr_jl.cpp
+++ b/orocos_kdl/src/chainiksolverpos_nr_jl.cpp
@@ -52,7 +52,7 @@ namespace KDL
 
     int ChainIkSolverPos_NR_JL::CartToJnt(const JntArray& q_init, const Frame& p_in, JntArray& q_out)
     {
-        if(nj != q_init.rows() || nj != q_out.rows())
+        if(nj != q_init.rows() || nj != q_out.rows() || nj != q_min.rows() || nj != q_max.rows())
             return (error = E_SIZE_MISMATCH);
 
             q_out = q_init;


### PR DESCRIPTION
ChainIkSolverPos_NR_JL does not currently check q_min and q_max size. 
Added the check in the CartToJnt function.
I am also wondering if there is a good way to check this in the constructor. 