### PR TITLE
KDL Frames/GetRotAngle:  Removed incorrect singularity checks and added unit tests for improper rotation matrices

### DIFF
--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -397,50 +397,23 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
         if ((xx > yy) && (xx > zz))
         {
             // data[0] is the largest diagonal term
-            if (xx < epsilon)
-            {
-                x = 0;
-                y = half_sqrt_2;
-                z = half_sqrt_2;
-            }
-            else
-            {
-                x = sqrt(xx);
-                y = xy/x;
-                z = xz/x;
-            }
+            x = sqrt(xx);
+            y = xy/x;
+            z = xz/x;
         }
         else if (yy > zz)
         {
             // data[4] is the largest diagonal term
-            if (yy < epsilon)
-            {
-                x = half_sqrt_2;
-                y = 0;
-                z = half_sqrt_2;
-            }
-            else
-            {
-                y = sqrt(yy);
-                x = xy/y;
-                z = yz/y;
-            }
+            y = sqrt(yy);
+            x = xy/y;
+            z = yz/y;
         }
         else
         {
             // data[8] is the largest diagonal term so base result on this
-            if (zz < epsilon)
-            {
-                x = half_sqrt_2;
-                y = half_sqrt_2;
-                z = 0;
-            }
-            else
-            {
-                z = sqrt(zz);
-                x = xz/z;
-                y = yz/z;
-            }
+            z = sqrt(zz);
+            x = xz/z;
+            y = yz/z;
         }
         axis = KDL::Vector(x, y, z);
         return angle; // return 180 deg rotation

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -438,6 +438,30 @@ void FramesTest::TestGetRotAngle() {
     double angle = KDL::Rotation(-1, 0, 0 + 1e-6, 0, 1, 0, 0, 0, -1 - 1e-6).GetRotAngle(axis);
     CPPUNIT_ASSERT_DOUBLES_EQUAL_MESSAGE("rot(NON-ORTHOGONAL, PI)", M_PI, angle, epsilon);
   }
+
+  // Tests to show that GetRotAngle does not work for an improper rotation matrix which has a determinant of -1;
+  // an improper rotation matrix corresponds to a rotation between a right-hand and left-hand coordinate system
+  {
+    Vector axis;
+    double angle;
+    Rotation R, Rout;
+    double det;
+    // Improper Rotation Matrix for 120 deg rotation
+    R = KDL::Rotation( 0, -1, 0, 0, 0, -1, -1, 0, 0);
+    det = +R(0,0)*(R(1,1)*R(2,2)-R(2,1)*R(1,2))-R(0,1)*(R(1,0)*R(2,2)-R(2,0)*R(1,2))+R(0,2)*(R(1,0)*R(2,1)-R(2,0)*R(1,1));
+    CPPUNIT_ASSERT_EQUAL(det,-1.0);
+    angle = R.GetRotAngle(axis);
+    Rout = KDL::Rotation::Rot(axis, angle);
+    CPPUNIT_ASSERT_ASSERTION_FAIL(CPPUNIT_ASSERT_EQUAL(R,Rout));
+    // Improper Rotation matrix for 180 deg rotation (singular)
+    R = KDL::Rotation( -1, 0, 0, 0, -1, 0, 0, 0, -1);
+    det = +R(0,0)*(R(1,1)*R(2,2)-R(2,1)*R(1,2))-R(0,1)*(R(1,0)*R(2,2)-R(2,0)*R(1,2))+R(0,2)*(R(1,0)*R(2,1)-R(2,0)*R(1,1));
+    CPPUNIT_ASSERT_EQUAL(det,-1.0);
+    angle = R.GetRotAngle(axis);
+    Rout = KDL::Rotation::Rot(axis, angle);
+    CPPUNIT_ASSERT_ASSERTION_FAIL(CPPUNIT_ASSERT_EQUAL(R,Rout));
+  }
+
 }
 
 void FramesTest::TestQuaternion() {


### PR DESCRIPTION
This pull request now contains two commits:  (1) frames.cpp to remove unnecessary code for singularity checks and (2) framestest.cpp to add tests for improper rotation matrices.

Commit:  Remove Unnecessary epsilon checks from GetRotAngle

The set of conditionals where xx, yy, and zz are checked for being < epsilon are searching for the case where the rotation matrix is the negative identity matrix. For example, if xx > yy and xx > zz and xx < epsilon, then the diagonal elements data[0], data[4], and data[8] are all approximately equal -1. Yet this will return an angle-axis of (0, 1/sqrt2, 1/sqrt2) which corresponds to a rotation matrix of [-1 0 0; 0 0 1; 0 1 0] which is not the negative identity matrix. The same is true for yy or zz being the largest value but still ~0. But the negative identity matrix is an improper rotation matrix so the checks should not be there.

Th code for GetRotAngle was transcribed from the java code at http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/index.htm. In the final entry under “Correspondence on this page”, Gene Gorokhovsky basically gives protocode for the 180 deg singularity case, which does not include the ‘ < epsilon ‘ checks. So it seems this was added as a way to prevent a divide by zero for the case of the negative identity matrix which is not a legal input.

Commit:  Added unit tests for improper rotation matrices for GetRotAngle

The function GetRotAngle() will return incorrect values if the rotation matrix is improper, that is, it represents a rotation between a right-handed and left-handed coordinate system.  An improper rotation matrix is also orthonormal, but it has a determinant of -1 instead of +1.  Two test cases have been added to confirm that GetRotAngle returns the incorrect rotation matrix that was input when the Rot function is applied to the output:  a non-singular rotation (120 deg) and a singular rotation (180 deg).  The negative identity matrix was cited at the end of the Singularities section in http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToAngle/index.htm as potentially problematic, but all improper rotation matrices will return incorrect values not just this singular case.  There is an implicit assumption throughout KDL that rotation matrices are all proper.