### PR TITLE
Adding setters and getters for RotationalInertia

### DIFF
--- a/python_orocos_kdl/PyKDL/kinfam.sip
+++ b/python_orocos_kdl/PyKDL/kinfam.sip
@@ -69,8 +69,27 @@ public:
     RotationalInertia(double Ixx=0,double Iyy=0,double Izz=0,double Ixy=0,double Ixz=0,double Iyz=0);
         
     static RotationalInertia Zero()/Factory/;
-    Vector operator*(Vector omega) const /Factory/;
+
+    double __getitem__(int index);
+%MethodCode
+    if (a0 < 0 || a0 >= 9) {
+        PyErr_SetString(PyExc_IndexError, "RotationalInertia index out of range");
+        return 0;
+    }
+    sipRes=(*sipCpp).data[a0];
+%End
+
+    void __setitem__(int i, double value);
+%MethodCode
+    if (a0 < 0 || a0 >= 9) {
+        PyErr_SetString(PyExc_IndexError, "RotationalInertia index out of range");
+        return 0;
+    }
+    (*sipCpp).data[a0]=a1;
+%End
+
 };
+Vector operator*(RotationalInertia& Ia, Vector omega) const /Factory/;
 RotationalInertia operator*(double a, const RotationalInertia& I)/Factory/;
 RotationalInertia operator+(const RotationalInertia& Ia, const RotationalInertia& Ib)/Factory/;
 


### PR DESCRIPTION
This also moves the definition for Inertia-Vector multiplication out of
the sip class body, which was causing a code generation problem.

@zchen24 Want to review?