### PR TITLE
Add joint inertia dynamics

### DIFF
--- a/orocos_kdl/src/chaindynparam.cpp
+++ b/orocos_kdl/src/chaindynparam.cpp
@@ -98,7 +98,8 @@ namespace KDL {
 	  F=Ic[i]*S[i];
 	  if(chain.getSegment(i).getJoint().getType()!=Joint::None)
 	  {
-	      H(k,k)=dot(S[i],F);
+          H(k,k)=dot(S[i],F);
+          H(k,k)+=chain.getSegment(i).getJoint().getInertia();  // add joint inertia
 	      j=k; //countervariable for the joints
 	      l=i; //countervariable for the segments
 	      while(l!=0) //go from leaf to root starting at i

--- a/orocos_kdl/src/chainidsolver_recursive_newton_euler.cpp
+++ b/orocos_kdl/src/chainidsolver_recursive_newton_euler.cpp
@@ -87,8 +87,11 @@ namespace KDL{
         //Sweep from leaf to root
         j=nj-1;
         for(int i=ns-1;i>=0;i--){
-            if(chain.getSegment(i).getJoint().getType()!=Joint::None)
-                torques(j--)=dot(S[i],f[i]);
+            if(chain.getSegment(i).getJoint().getType()!=Joint::None){
+                torques(j)=dot(S[i],f[i]);
+                torques(j)+=chain.getSegment(i).getJoint().getInertia()*q_dotdot(j);  // add torque from joint inertia
+                --j;
+            }
             if(i!=0)
                 f[i-1]=f[i-1]+X[i]*f[i];
         }

--- a/orocos_kdl/src/joint.hpp
+++ b/orocos_kdl/src/joint.hpp
@@ -192,6 +192,16 @@ namespace KDL {
             }
         };
 
+        /**
+         * Request the inertia of the joint.
+         *
+         * @return const reference to the inertia of the joint
+         */
+        const double& getInertia() const
+        {
+            return inertia;
+        };
+
         virtual ~Joint();
 
     private:


### PR DESCRIPTION
The effective motor inertia at the link output (motor inertia times gear ratio squared) can be significant and even exceed the link inertia.  The effective motor inertia can be modeled as "joint" inertia in the chain, which can be extracted and used in the recursive newton-euler dynamics.  The three commits in this pull request do the following:
1.  creates function in Joint Class to extract the joint inertia
2. adds the joint inertia to the diagonal elements of the joint space inertia matrix in the ChainParamDyn Class
3. adds the inertial torque due to the joint inertia in the ChainIdSolver_RNE Class
Note that #3 should also be done for the ChainIdSolver_Vereshchagin Class, but I do not understand this algorithm enough to make those changes.