### PR TITLE
Remove const reference'd chains from solvers. Fixes #147

### DIFF
--- a/orocos_kdl/src/chaindynparam.hpp
+++ b/orocos_kdl/src/chaindynparam.hpp
@@ -58,7 +58,7 @@ namespace KDL {
     virtual void updateInternalDataStructures();
 
     private:
-        const Chain& chain;
+        const Chain chain;
 	int nr;
 	unsigned int nj;
         unsigned int ns;	

--- a/orocos_kdl/src/chainfksolverpos_recursive.hpp
+++ b/orocos_kdl/src/chainfksolverpos_recursive.hpp
@@ -45,7 +45,7 @@ namespace KDL {
         virtual void updateInternalDataStructures() {};
 
     private:
-        const Chain& chain;
+        const Chain chain;
     };
 
 }

--- a/orocos_kdl/src/chainfksolvervel_recursive.hpp
+++ b/orocos_kdl/src/chainfksolvervel_recursive.hpp
@@ -44,7 +44,7 @@ namespace KDL
         virtual int JntToCart(const JntArrayVel& q_in,std::vector<FrameVel>& out,int segmentNr=-1);
         virtual void updateInternalDataStructures() {};
     private:
-        const Chain& chain;
+        const Chain chain;
     };
 }
 

--- a/orocos_kdl/src/chainidsolver_recursive_newton_euler.hpp
+++ b/orocos_kdl/src/chainidsolver_recursive_newton_euler.hpp
@@ -63,7 +63,7 @@ namespace KDL{
         virtual void updateInternalDataStructures();
 
     private:
-        const Chain& chain;
+        const Chain chain;
         unsigned int nj;
         unsigned int ns;
         std::vector<Frame> X;

--- a/orocos_kdl/src/chainidsolver_vereshchagin.hpp
+++ b/orocos_kdl/src/chainidsolver_vereshchagin.hpp
@@ -122,7 +122,7 @@ private:
     void final_upwards_sweep(JntArray &q_dotdot, JntArray &torques);
 
 private:
-    const Chain& chain;
+    const Chain chain;
     unsigned int nj;
     unsigned int ns;
     unsigned int nc;

--- a/orocos_kdl/src/chainiksolverpos_lma.hpp
+++ b/orocos_kdl/src/chainiksolverpos_lma.hpp
@@ -157,7 +157,7 @@ public:
     virtual const char* strError(const int error) const;
 
 private:
-    const KDL::Chain& chain;
+    const KDL::Chain chain;
     unsigned int nj;
     unsigned int ns;
 

--- a/orocos_kdl/src/chainiksolverpos_nr.hpp
+++ b/orocos_kdl/src/chainiksolverpos_nr.hpp
@@ -79,7 +79,7 @@ namespace KDL {
         /// @copydoc KDL::SolverI::updateInternalDataStructures
         virtual void updateInternalDataStructures();
     private:
-        const Chain& chain;
+        const Chain chain;
 
         unsigned int nj;
         ChainIkSolverVel& iksolver;

--- a/orocos_kdl/src/chainiksolverpos_nr_jl.hpp
+++ b/orocos_kdl/src/chainiksolverpos_nr_jl.hpp
@@ -109,7 +109,7 @@ namespace KDL {
         const char* strError(const int error) const;
 
     private:
-        const Chain& chain;
+        const Chain chain;
         unsigned int nj;
         JntArray q_min;
         JntArray q_max;

--- a/orocos_kdl/src/chainiksolvervel_pinv.hpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv.hpp
@@ -98,7 +98,7 @@ namespace KDL
         /// @copydoc KDL::SolverI::updateInternalDataStructures
         virtual void updateInternalDataStructures();
     private:
-        const Chain& chain;
+        const Chain chain;
         ChainJntToJacSolver jnt2jac;
         unsigned int nj;
         Jacobian jac;

--- a/orocos_kdl/src/chainiksolvervel_pinv_givens.hpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv_givens.hpp
@@ -50,7 +50,7 @@ namespace KDL
         virtual void updateInternalDataStructures();
 
     private:
-        const Chain& chain;
+        const Chain chain;
         unsigned int nj;
         ChainJntToJacSolver jnt2jac;
         Jacobian jac;

--- a/orocos_kdl/src/chainiksolvervel_pinv_nso.hpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv_nso.hpp
@@ -138,7 +138,7 @@ namespace KDL
         virtual void updateInternalDataStructures();
 
     private:
-        const Chain& chain;
+        const Chain chain;
         ChainJntToJacSolver jnt2jac;
         unsigned int nj;
         Jacobian jac;

--- a/orocos_kdl/src/chainiksolvervel_wdls.hpp
+++ b/orocos_kdl/src/chainiksolvervel_wdls.hpp
@@ -216,7 +216,7 @@ namespace KDL
         virtual void updateInternalDataStructures();
 
     private:
-        const Chain& chain;
+        const Chain chain;
         ChainJntToJacSolver jnt2jac;
         unsigned int nj;
         Jacobian jac;

--- a/orocos_kdl/src/chainjnttojacdotsolver.hpp
+++ b/orocos_kdl/src/chainjnttojacdotsolver.hpp
@@ -164,8 +164,8 @@ protected:
                                const unsigned int& column_idx,
                                const int& representation);
 private:
-    
-    const Chain& chain;
+
+    const Chain chain;
     std::vector<bool> locked_joints_;
     unsigned int nr_of_unlocked_joints_;
     ChainJntToJacSolver jac_solver_;

--- a/orocos_kdl/src/chainjnttojacsolver.hpp
+++ b/orocos_kdl/src/chainjnttojacsolver.hpp
@@ -68,11 +68,10 @@ namespace KDL
         virtual void updateInternalDataStructures();
 
     private:
-        const Chain& chain;
+        const Chain chain;
         Twist t_tmp;
         Frame T_tmp;
         std::vector<bool> locked_joints_;
     };
 }
 #endif
-


### PR DESCRIPTION
Storing the chains as const references is risky, as the passed chain can be destroyed outside of the solver.