### PR TITLE
Create chain forward dynamics solver class

### DIFF
--- a/orocos_kdl/src/chainfdsolver.hpp
+++ b/orocos_kdl/src/chainfdsolver.hpp
@@ -1,0 +1,61 @@
+// Copyright  (C)  2018  Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+
+// Version: 1.0
+// Author: Ruben Smits, Craig Carignan
+// Maintainer: Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef KDL_CHAIN_FDSOLVER_HPP
+#define KDL_CHAIN_FDSOLVER_HPP
+
+#include "chain.hpp"
+#include "frames.hpp"
+#include "jntarray.hpp"
+#include "solveri.hpp"
+
+namespace KDL
+{
+
+    typedef std::vector<Wrench> Wrenches;
+
+	/**
+	 * \brief This <strong>abstract</strong> class encapsulates the inverse
+	 * dynamics solver for a KDL::Chain.
+	 *
+	 */
+	class ChainFdSolver : public KDL::SolverI
+	{
+		public:
+			/**
+			 * Calculate forward dynamics from joint positions, joint velocities, joint torques/forces,
+			 * and externally applied forces/torques to joint accelerations.
+			 *
+			 * @param q input joint positions
+			 * @param q_dot input joint velocities
+             * @param torque input joint torques
+             * @param f_ext external forces
+			 *
+             * @param q_dotdot output joint accelerations
+			 *
+			 * @return if < 0 something went wrong
+			 */
+        virtual int CartToJnt(const JntArray &q, const JntArray &q_dot, const JntArray &torques, const Wrenches& f_ext,JntArray &q_dotdot)=0;
+	};
+
+}
+
+#endif

--- a/orocos_kdl/src/chainfdsolver_recursive_newton_euler.cpp
+++ b/orocos_kdl/src/chainfdsolver_recursive_newton_euler.cpp
@@ -1,0 +1,138 @@
+// Copyright  (C)  2018  Craig Carignan <craigc at ssl dot umd dot edu>
+
+// Version: 1.0
+// Author: Craig Carignan <craigc at ssl dot umd dot edu>
+// Maintainer: Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "chainfdsolver_recursive_newton_euler.hpp"
+#include "utilities/ldl_solver_eigen.hpp"
+#include "frames_io.hpp"
+#include "kinfam_io.hpp"
+
+namespace KDL{
+
+    ChainFdSolver_RNE::ChainFdSolver_RNE(const Chain& _chain, Vector _grav):
+        chain(_chain),
+        DynSolver(chain, _grav),
+        IdSolver(chain, _grav),
+        nj(chain.getNrOfJoints()),
+        ns(chain.getNrOfSegments()),
+        H(nj),
+        Tzeroacc(nj),
+        H_eig(nj,nj),
+        Tzeroacc_eig(nj),
+        L_eig(nj,nj),
+        D_eig(nj),
+        r_eig(nj),
+        acc_eig(nj)
+    {
+    }
+
+    void ChainFdSolver_RNE::updateInternalDataStructures() {
+        nj = chain.getNrOfJoints();
+        ns = chain.getNrOfSegments();
+    }
+
+    int ChainFdSolver_RNE::CartToJnt(const JntArray &q, const JntArray &q_dot, const JntArray &torques, const Wrenches& f_ext, JntArray &q_dotdot)
+    {
+        if(nj != chain.getNrOfJoints() || ns != chain.getNrOfSegments())
+            return (error = E_NOT_UP_TO_DATE);
+
+        //Check sizes of function parameters
+        if(q.rows()!=nj || q_dot.rows()!=nj || q_dotdot.rows()!=nj || torques.rows()!=nj || f_ext.size()!=ns)
+            return (error = E_SIZE_MISMATCH);
+
+        // Inverse Dynamics:
+        //   T = H * qdd + Tcor + Tgrav - J^T * Fext
+        // Forward Dynamics:
+        //   1. Call ChainDynParam->JntToMass to get H
+        //   2. Call ChainIdSolver_RNE->CartToJnt with qdd=0 to get Tcor+Tgrav-J^T*Fext
+        //   3. Calculate qdd = H^-1 * T where T are applied joint torques minus non-inertial internal torques
+
+        // Calculate Joint Space Inertia Matrix
+        error = DynSolver.JntToMass(q, H);
+        if (error < 0)
+            return (error);
+
+        // Calculate non-inertial internal torques by inputting zero joint acceleration to ID
+        for(int i=0;i<nj;i++){
+            q_dotdot(i) = 0.;
+        }
+        error = IdSolver.CartToJnt(q, q_dot, q_dotdot, f_ext, Tzeroacc);
+        if (error < 0)
+            return (error);
+
+        // Calculate acceleration using inverse symmetric matrix times vector
+        for(int i=0;i<nj;i++){
+            Tzeroacc_eig(i) =  (torques(i)-Tzeroacc(i));
+            for(int j=0;j<nj;j++){
+                H_eig(i,j) =  H(i,j);
+            }
+        }
+        ldl_solver_eigen(H_eig, Tzeroacc_eig, L_eig, D_eig, r_eig, acc_eig);
+        for(int i=0;i<nj;i++){
+            q_dotdot(i) = acc_eig(i);
+        }
+
+        return (error = E_NOERROR);
+    }
+
+    void ChainFdSolver_RNE::RK4Integrator(int& nj, const double& t, double& dt, KDL::JntArray& q, KDL::JntArray& q_dot,
+                                          KDL::JntArray& torques, KDL::Wrenches& f_ext, KDL::ChainFdSolver_RNE& fdsolver,
+                                          KDL::JntArray& q_dotdot, KDL::JntArray& dq, KDL::JntArray& dq_dot,
+                                          KDL::JntArray& q_temp, KDL::JntArray& q_dot_temp)
+    {
+        fdsolver.CartToJnt(q, q_dot, torques, f_ext, q_dotdot);
+        for (int i=0; i<nj; ++i)
+        {
+            q_temp(i) = q(i) + q_dot(i)*dt/2.0;
+            q_dot_temp(i) = q_dot(i) + q_dotdot(i)*dt/2.0;
+            dq(i) = q_dot(i);
+            dq_dot(i) = q_dotdot(i);
+        }
+        fdsolver.CartToJnt(q_temp, q_dot_temp, torques, f_ext, q_dotdot);
+        for (int i=0; i<nj; ++i)
+        {
+            q_temp(i) = q(i) + q_dot_temp(i)*dt/2.0;
+            q_dot_temp(i) = q_dot(i) + q_dotdot(i)*dt/2.0;
+            dq(i) += 2.0*q_dot_temp(i);
+            dq_dot(i) += 2.0*q_dotdot(i);
+        }
+        fdsolver.CartToJnt(q_temp, q_dot_temp, torques, f_ext, q_dotdot);
+        for (int i=0; i<nj; ++i)
+        {
+            q_temp(i) = q(i) + q_dot_temp(i)*dt;
+            q_dot_temp(i) = q_dot(i) + q_dotdot(i)*dt;
+            dq(i) += 2.0*q_dot_temp(i);
+            dq_dot(i) += 2.0*q_dotdot(i);
+        }
+        fdsolver.CartToJnt(q_temp, q_dot_temp, torques, f_ext, q_dotdot);
+        for (int i=0; i<nj; ++i)
+        {
+            dq(i) = (dq(i)+q_dot_temp(i))*dt/6.0;
+            dq_dot(i) = (dq_dot(i)+q_dotdot(i))*dt/6.0;
+        }
+        for (int i=0; i<nj; ++i)
+        {
+            q(i) += dq(i);
+            q_dot(i) += dq_dot(i);
+        }
+        return;
+    }
+
+}//namespace

--- a/orocos_kdl/src/chainfdsolver_recursive_newton_euler.hpp
+++ b/orocos_kdl/src/chainfdsolver_recursive_newton_euler.hpp
@@ -1,0 +1,111 @@
+// Copyright  (C)  2018  Craig Carignan <craigc at ssl dot umd dot edu>
+
+// Version: 1.0
+// Author: Craig Carignan  <craigc at ssl dot umd dot edu>
+// Maintainer: Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef KDL_CHAIN_FDSOLVER_RECURSIVE_NEWTON_EULER_HPP
+#define KDL_CHAIN_FDSOLVER_RECURSIVE_NEWTON_EULER_HPP
+
+#include "chainfdsolver.hpp"
+#include "chainidsolver_recursive_newton_euler.hpp"
+#include "chaindynparam.hpp"
+
+namespace KDL{
+    /**
+     * \brief Recursive newton euler forward dynamics solver
+     *
+     * The algorithm implementation is based on the book "Rigid Body
+     * Dynamics Algorithms" of Roy Featherstone, 2008
+     * (ISBN:978-0-387-74314-1) See Chapter 6 for basic algorithm.
+     *
+     * It calculates the accelerations for the joints (qdotdot), given the
+     * position and velocity of the joints (q,qdot,qdotdot), external forces
+     * on the segments (expressed in the segments reference frame),
+     * and the dynamical parameters of the segments.
+     */
+    class ChainFdSolver_RNE : public ChainFdSolver{
+    public:
+        /**
+         * Constructor for the solver, it will allocate all the necessary memory
+         * \param chain The kinematic chain to calculate the forward dynamics for, an internal copy will be made.
+         * \param grav The gravity vector to use during the calculation.
+         */
+        ChainFdSolver_RNE(const Chain& chain, Vector grav);
+        ~ChainFdSolver_RNE(){};
+
+        /**
+         * Function to calculate from Cartesian forces to joint torques.
+         * Input parameters;
+         * \param q The current joint positions
+         * \param q_dot The current joint velocities
+         * \param torques The current joint torques (applied by controller)
+         * \param f_ext The external forces (no gravity) on the segments
+         * Output parameters:
+         * \param q_dotdot The resulting joint accelerations
+         */
+        int CartToJnt(const JntArray &q, const JntArray &q_dot, const JntArray &torques, const Wrenches& f_ext, JntArray &q_dotdot);
+
+        /// @copydoc KDL::SolverI::updateInternalDataStructures
+        virtual void updateInternalDataStructures();
+
+        /**
+         * Function to integrate the joint accelerations resulting from the forward dynamics solver.
+         * Input parameters;
+         * \param nj The number of joints
+         * \param t The current time
+         * \param dt The integration period
+         * \param q The current joint positions
+         * \param q_dot The current joint velocities
+         * \param torques The current joint torques (applied by controller)
+         * \param f_ext The external forces (no gravity) on the segments
+         * \param fdsolver The forward dynamics solver
+         * Output parameters:
+         * \param t The updated time
+         * \param q The updated joint positions
+         * \param q_dot The updated joint velocities
+         * \param q_dotdot The current joint accelerations
+         * \param dq The joint position increment
+         * \param dq_dot The joint velocity increment
+         * Temporary parameters:
+         * \param qtemp Intermediate joint positions
+         * \param qdtemp Intermediate joint velocities
+         */
+        void RK4Integrator(int& nj, const double& t, double& dt, KDL::JntArray& q, KDL::JntArray& q_dot,
+                           KDL::JntArray& torques, KDL::Wrenches& f_ext, KDL::ChainFdSolver_RNE& fdsolver,
+                           KDL::JntArray& q_dotdot, KDL::JntArray& dq, KDL::JntArray& dq_dot,
+                           KDL::JntArray& q_temp, KDL::JntArray& q_dot_temp);
+
+    private:
+        const Chain& chain;
+        ChainDynParam DynSolver;
+        ChainIdSolver_RNE IdSolver;
+        unsigned int nj;
+        unsigned int ns;
+        JntArray Tzeroacc;
+        JntSpaceInertiaMatrix H;
+        Eigen::MatrixXd H_eig;
+        Eigen::VectorXd Tzeroacc_eig;
+        Eigen::MatrixXd L_eig;
+        Eigen::VectorXd D_eig;
+        Eigen::VectorXd r_eig;
+        Eigen::VectorXd acc_eig;
+    };
+}
+
+#endif

--- a/orocos_kdl/src/utilities/ldl_solver_eigen.cpp
+++ b/orocos_kdl/src/utilities/ldl_solver_eigen.cpp
@@ -1,0 +1,82 @@
+// Copyright  (C)  2018  Craig Carignan <craigc at ssl dot umd dot edu>
+
+// Version: 1.0
+// Author: Craig Carignan
+// Maintainer: Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "ldl_solver_eigen.hpp"
+
+namespace KDL{
+
+    int ldl_solver_eigen(const Eigen::MatrixXd& A, const Eigen::VectorXd& v, Eigen::MatrixXd& L, Eigen::VectorXd& D, Eigen::VectorXd& vtmp, Eigen::VectorXd& q)
+    {
+        const int n = A.rows();
+        int error=SolverI::E_NOERROR;
+
+        //Check sizes
+        if(A.cols()!=n || v.rows()!=n || L.rows()!=n || L.cols()!=n || D.rows()!=n || vtmp.rows()!=n || q.rows()!=n)
+            return (error = SolverI::E_SIZE_MISMATCH);
+
+        for(int i=0;i<n;++i)  {
+            D(i)=A(i,i);
+            if(i>0) {
+                for(int j=0;j<=i-1;++j)
+                    D(i) -= D(j)*L(i,j)*L(i,j);
+            }
+            for(int j=1;j<n;++j)  {
+                if(j>i)  {
+                    L(j,i)=A(i,j)/D(i);
+                    if(i>0)  {
+                        for(int k=0;k<=i-1;++k)
+                            L(j,i) -= L(j,k)*L(i,k)*D(k)/D(i);
+                    }
+                }
+            }
+        }
+        for(int i=0;i<n;++i)  {
+            vtmp(i)=v(i);
+            if(i>0) {
+                for(int j=0;j<=i-1;++j)
+                    vtmp(i) -= L(i,j)*vtmp(j);
+            }
+        }
+        for(int i=n-1;i>=0;--i) {
+            q(i)=vtmp(i)/D(i);
+            if(i<n-1)  {
+                for(int j=i+1;j<n;++j)
+                    q(i) -= L(j,i)*q(j);
+            }
+        }
+        // optional: changes diagonal elements of L to 1 as per LDL decomposition
+        //           A = L * Ddiag * L^T where Ddiag(i,i) = D(i)
+        for(int i=0;i<n;++i)  {
+            L(i,i) = 1.;
+        }
+        // optional: sets upper triangular, off-diagonal elements of L to 0
+        //           because algorithm does not do this automatically
+        if ( n > 1 )
+        {
+            for(int i=0;i<n;++i)  {
+                for(int j=i+1;j<n;++j)  {
+                    L(i,j) = 0.0;
+                }
+            }
+        }
+        return(error);
+    }
+}

--- a/orocos_kdl/src/utilities/ldl_solver_eigen.hpp
+++ b/orocos_kdl/src/utilities/ldl_solver_eigen.hpp
@@ -1,0 +1,59 @@
+// Copyright  (C)  2018  Craig Carignan <craigc at ssl dot umd dot edu>
+
+// Version: 1.0
+// Author: Craig Carignan
+// Maintainer: Ruben Smits <ruben dot smits at mech dot kuleuven dot be>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+
+// Inverse of a positive definite symmetric matrix times a vector
+// based on LDL^T Decomposition
+#ifndef LDL_SOLVER_EIGEN_HPP
+#define LDL_SOLVER_EIGEN_HPP
+
+
+#include <Eigen/Core>
+#include "../solveri.hpp"
+
+using namespace Eigen;
+
+namespace KDL
+{
+    /**
+     * \brief Solves the system of equations Aq = v for q via LDL decomposition,
+     *        where A is a square positive definite matrix
+     *
+     * The algorithm factor A into the product of three matrices LDL^T, where L
+     * is a lower triangular matrix and D is a diagonal matrix.  This allows q
+     * to be computed without explicity inverting A.  Note that the LDL decomposition
+     * is a variant of the classical Cholesky Decomposition that does not require
+     * the computation of square roots.
+     * Input parameters:
+     * @param A matrix<double>(nxn)
+     * @param v vector<double> n
+     * @param vtmp vector<double> n [temp variable]
+     * Output parameters:
+     * @param L matrix<double>(nxn)
+     * @param D vector<double> n
+     * @param q vector<double> n
+     * @return 0 if successful, E_SIZE_MISMATCH if dimensions do not match
+     * References:
+     * https://en.wikipedia.org/wiki/Cholesky_decomposition
+     */
+    int ldl_solver_eigen(const Eigen::MatrixXd& A, const Eigen::VectorXd& v, Eigen::MatrixXd& L, Eigen::VectorXd& D, Eigen::VectorXd& vtmp, Eigen::VectorXd& q);
+}
+#endif

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -1190,7 +1190,7 @@ void SolverTest::LDLdecompTest()
 
     // Verify solution for x
     for(int i=0;i<3;i++){
-        xout(i,i) = x(i);
+        CPPUNIT_ASSERT(Equal(xout(i), x(i), eps));
     }
 
     // Test reconstruction of A from LDL^T decomposition

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -1147,3 +1147,59 @@ void SolverTest::FdSolverConsistencyTest()
 
     return;
 }
+
+void SolverTest::LDLdecompTest()
+{
+    std::cout<<"LDL Solver Test"<<std::endl;
+    double eps=1.e-6;
+
+    //  Given A and b, solve Ax=b for x, where A is a symmetric real matrix
+    //  https://en.wikipedia.org/wiki/Cholesky_decomposition
+    Eigen::MatrixXd A(3,3), Aout(3,3);
+    Eigen::VectorXd b(3);
+    Eigen::MatrixXd L(3,3), Lout(3,3);
+    Eigen::VectorXd d(3), dout(3);
+    Eigen::VectorXd x(3), xout(3);
+    Eigen::VectorXd r(3);  // temp variable used internally by ldl solver
+    Eigen::MatrixXd Dout(3,3);  // diagonal matrix
+
+    // Given
+    A <<  4, 12, -16,
+         12, 37, -43,
+        -16, -43, 98;
+    b << 28, 117, 98;
+    // Results to verify
+    L <<  1, 0, 0,
+          3, 1, 0,
+          -4, 5, 1;
+    d << 4, 1, 9;
+    x << 3, 8, 5;
+
+    ldl_solver_eigen(A, b, Lout, dout, r, xout);
+
+    for(int i=0;i<3;i++){
+        for(int j=0;j<3;j++){
+            CPPUNIT_ASSERT(Equal(L(i,j), Lout(i,j), eps));
+        }
+    }
+
+    Dout.setZero();
+    for(int i=0;i<3;i++){
+        Dout(i,i) = dout(i);
+    }
+
+    // Verify solution for x
+    for(int i=0;i<3;i++){
+        xout(i,i) = x(i);
+    }
+
+    // Test reconstruction of A from LDL^T decomposition
+    Aout = Lout * Dout * Lout.transpose();
+    for(int i=0;i<3;i++){
+        for(int j=0;j<3;j++){
+            CPPUNIT_ASSERT(Equal(A(i,j), Aout(i,j), eps));
+        }
+    }
+
+    return;
+}

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -119,6 +119,57 @@ void SolverTest::setUp()
 									Frame::DH_Craig1989(0.0, -M_PI_2, 0.0, 0.0)));
 	motomansia10.addSegment(Segment(Joint(Joint::RotZ),
 									Frame(Rotation::Identity(),Vector(0.0,0.0,0.155))));
+
+    // Motoman SIA10 Chain with Mass Parameters (for forward dynamics tests)
+
+    //  effective motor inertia is included as joint inertia
+    static const double scale=1;
+    static const double offset=0;
+    static const double inertiamotorA=5.0;      // effective motor inertia kg-m^2
+    static const double inertiamotorB=3.0;      // effective motor inertia kg-m^2
+    static const double inertiamotorC=1.0;      // effective motor inertia kg-m^2
+    static const double damping=0;
+    static const double stiffness=0;
+
+    //  Segment Inertias
+    KDL::RigidBodyInertia inert1(15.0, KDL::Vector(0.0, -0.02, 0.0),                       // mass, CM
+                                 KDL::RotationalInertia(0.1, 0.05, 0.1, 0.0, 0.0, 0.0));   // inertia
+    KDL::RigidBodyInertia inert2(5.0, KDL::Vector(0.0, -0.02, -0.1),
+                                 KDL::RotationalInertia(0.01, 0.1, 0.1, 0.0, 0.0, 0.0));
+    KDL::RigidBodyInertia inert3(5.0, KDL::Vector(0.0, -0.05, 0.02),
+                                 KDL::RotationalInertia(0.05, 0.01, 0.05, 0.0, 0.0, 0.0));
+    KDL::RigidBodyInertia inert4(3.0, KDL::Vector(0.0, 0.02, -0.15),
+                                 KDL::RotationalInertia(0.1, 0.1, 0.01, 0.0, 0.0, 0.0));
+    KDL::RigidBodyInertia inert5(3.0, KDL::Vector(0.0, -0.05, 0.01),
+                                 KDL::RotationalInertia(0.02, 0.01, 0.02, 0.0, 0.0, 0.0));
+    KDL::RigidBodyInertia inert6(3.0, KDL::Vector(0.0, -0.01, -0.1),
+                                 KDL::RotationalInertia(0.1, 0.1, 0.01, 0.0, 0.0, 0.0));
+    KDL::RigidBodyInertia inert7(1.0, KDL::Vector(0.0, 0.0, 0.05),
+                                 KDL::RotationalInertia(0.01, 0.01, 0.1, 0.0, 0.0, 0.0));
+
+    motomansia10dyn.addSegment(Segment(Joint(Joint::RotZ, scale, offset, inertiamotorA, damping, stiffness),
+                               Frame::DH(0.0, M_PI_2, 0.36, 0.0),
+                               inert1));
+    motomansia10dyn.addSegment(Segment(Joint(Joint::RotZ, scale, offset, inertiamotorA, damping, stiffness),
+                               Frame::DH(0.0, -M_PI_2, 0.0, 0.0),
+                               inert2));
+    motomansia10dyn.addSegment(Segment(Joint(Joint::RotZ, scale, offset, inertiamotorB, damping, stiffness),
+                               Frame::DH(0.0, M_PI_2, 0.36, 0.0),
+                               inert3));
+    motomansia10dyn.addSegment(Segment(Joint(Joint::RotZ, scale, offset, inertiamotorB, damping, stiffness),
+                               Frame::DH(0.0, -M_PI_2, 0.0, 0.0),
+                               inert4));
+    motomansia10dyn.addSegment(Segment(Joint(Joint::RotZ, scale, offset, inertiamotorC, damping, stiffness),
+                               Frame::DH(0.0, M_PI_2, 0.36, 0.0),
+                               inert5));
+    motomansia10dyn.addSegment(Segment(Joint(Joint::RotZ, scale, offset, inertiamotorC, damping, stiffness),
+                               Frame::DH(0.0, -M_PI_2, 0.0, 0.0),
+                               inert6));
+    motomansia10dyn.addSegment(Segment(Joint(Joint::RotZ, scale, offset, inertiamotorC, damping, stiffness),
+                               Frame::DH(0.0, 0.0, 0.0, 0.0),
+                               inert7));
+    motomansia10dyn.addSegment(Segment(Joint(Joint::None),
+                                       Frame(Rotation::Identity(),Vector(0.0,0.0,0.155))));
 }
 
 void SolverTest::tearDown()
@@ -846,4 +897,253 @@ void SolverTest::FkVelVectTest()
     fksolver1.JntToCart(qvel,f_out);
     
     CPPUNIT_ASSERT(Equal(v_out[chain1.getNrOfSegments()-1],f_out,1e-5));
+}
+
+void SolverTest::FdSolverDevelopmentTest()
+{
+    int ret;
+    double eps=1.e-3;
+
+    std::cout<<"KDL FD Solver Development Test for Motoman SIA10"<<std::endl;
+
+    //  NOTE:  This is prototype code for the KDL forward dynamics solver class
+    //         based on the Recurse Newton Euler Method:  ChainFdSolver_RNE
+
+    //  Dynamics Solver
+    Vector gravity(0.0, 0.0, -9.81);  // base frame
+    ChainDynParam DynSolver = KDL::ChainDynParam(motomansia10dyn, gravity);
+
+    unsigned int nj = motomansia10dyn.getNrOfJoints();
+    unsigned int ns = motomansia10dyn.getNrOfSegments();
+
+    // Joint position, velocity, and acceleration
+    JntArray q(nj);
+    JntArray qd(nj);
+    JntArray qdd(nj);
+
+    //  random
+    q(0) = 0.2;
+    q(1) = 0.6;
+    q(2) = 1.;
+    q(3) = 0.5;
+    q(4) = -1.4;
+    q(5) = 0.3;
+    q(6) = -0.8;
+
+    qd(0) = 1.;
+    qd(1) = -2.;
+    qd(2) = 3.;
+    qd(3) = -4.;
+    qd(4) = 5.;
+    qd(5) = -6.;
+    qd(6) = 7.;
+
+    // Validate FK
+    ChainFkSolverPos_recursive fksolver(motomansia10dyn);
+    Frame f_out;
+    fksolver.JntToCart(q,f_out);
+    CPPUNIT_ASSERT(Equal(-0.547, f_out.p(0), eps));
+    CPPUNIT_ASSERT(Equal(-0.301, f_out.p(1), eps));
+    CPPUNIT_ASSERT(Equal(0.924, f_out.p(2), eps));
+    CPPUNIT_ASSERT(Equal(0.503, f_out.M(0,0), eps));
+    CPPUNIT_ASSERT(Equal(0.286, f_out.M(0,1), eps));
+    CPPUNIT_ASSERT(Equal(-0.816, f_out.M(0,2), eps));
+    CPPUNIT_ASSERT(Equal(-0.859, f_out.M(1,0), eps));
+    CPPUNIT_ASSERT(Equal(0.269, f_out.M(1,1), eps));
+    CPPUNIT_ASSERT(Equal(-0.436, f_out.M(1,2), eps));
+    CPPUNIT_ASSERT(Equal(0.095, f_out.M(2,0), eps));
+    CPPUNIT_ASSERT(Equal(0.920, f_out.M(2,1), eps));
+    CPPUNIT_ASSERT(Equal(0.381, f_out.M(2,2), eps));
+
+    // Validate Jacobian
+    ChainJntToJacSolver jacsolver(motomansia10dyn);
+    Jacobian jac(nj);
+    jacsolver.JntToJac(q, jac);
+    double Jac[6][7] =
+        {{0.301,-0.553,0.185,0.019,0.007,-0.086,0.},
+        {-0.547,-0.112,-0.139,-0.376,-0.037,0.063,0.},
+        {0.,-0.596,0.105,-0.342,-0.026,-0.113,0.},
+        {0.,0.199,-0.553,0.788,-0.615,0.162,-0.816},
+        {0.,-0.980,-0.112,-0.392,-0.536,-0.803,-0.436},
+        {1.,0.,0.825,0.475,0.578,-0.573,0.381}};
+    for ( int i=0; i<6; i++ ) {
+        for ( int j=0; j<nj; j++ ) {
+            CPPUNIT_ASSERT(Equal(jac(i,j), Jac[i][j], eps));
+        }
+    }
+
+    // Return values
+    JntArray taugrav(nj);
+    JntArray taucor(nj);
+    JntSpaceInertiaMatrix H(nj), Heff(nj);
+
+    // Compute Dynamics (torque in N-m)
+    ret = DynSolver.JntToGravity(q, taugrav);
+    if (ret < 0) std::cout << "KDL: inverse dynamics ERROR: " << ret << std::endl;
+    CPPUNIT_ASSERT(Equal(0.000, taugrav(0), eps));
+    CPPUNIT_ASSERT(Equal(-36.672, taugrav(1), eps));
+    CPPUNIT_ASSERT(Equal(4.315, taugrav(2), eps));
+    CPPUNIT_ASSERT(Equal(-11.205, taugrav(3), eps));
+    CPPUNIT_ASSERT(Equal(0.757, taugrav(4), eps));
+    CPPUNIT_ASSERT(Equal(1.780, taugrav(5), eps));
+    CPPUNIT_ASSERT(Equal(0.000, taugrav(6), eps));
+
+    ret = DynSolver.JntToCoriolis(q, qd, taucor);
+    if (ret < 0) std::cout << "KDL: inverse dynamics ERROR: " << ret << std::endl;
+    CPPUNIT_ASSERT(Equal(-15.523, taucor(0), eps));
+    CPPUNIT_ASSERT(Equal(24.250, taucor(1), eps));
+    CPPUNIT_ASSERT(Equal(-6.862, taucor(2), eps));
+    CPPUNIT_ASSERT(Equal(6.303, taucor(3), eps));
+    CPPUNIT_ASSERT(Equal(0.110, taucor(4), eps));
+    CPPUNIT_ASSERT(Equal(-4.898, taucor(5), eps));
+    CPPUNIT_ASSERT(Equal(-0.249, taucor(6), eps));
+
+    ret = DynSolver.JntToMass(q, H);
+    if (ret < 0) std::cout << "KDL: inverse dynamics ERROR: " << ret << std::endl;
+    double Hexp[7][7] =
+        {{6.8687,-0.4333,0.4599,0.6892,0.0638,-0.0054,0.0381},
+        {-0.4333,8.8324,-0.5922,0.7905,0.0003,-0.0242,0.0265},
+        {0.4599,-0.5922,3.3496,-0.0253,0.1150,-0.0243,0.0814},
+        {0.6892,0.7905,-0.0253,3.9623,-0.0201,0.0087,-0.0291},
+        {0.0638,0.0003,0.1150,-0.0201,1.1234,0.0029,0.0955},
+        {-0.0054,-0.0242,-0.0243,0.0087,0.0029,1.1425,0},
+        {0.0381,0.0265,0.0814,-0.0291,0.0955,0,1.1000}};
+    for ( int i=0; i<nj; i++ ) {
+        for ( int j=0; j<nj; j++ ) {
+            CPPUNIT_ASSERT(Equal(H(i,j), Hexp[i][j], eps));
+        }
+    }
+
+    // Inverse Dynamics:
+    //   T = H * qdd + Tcor + Tgrav - J^T * Fext
+    // Forward Dynamics
+    //   1. Call JntToMass from ChainDynParam to get H
+    //   2. Call ID with qdd=0 to get T=Tcor+Tgrav+J^T*Fext
+    //   3. Calculate qdd = H^-1 * T
+    KDL::ChainIdSolver_RNE IdSolver = KDL::ChainIdSolver_RNE(motomansia10dyn, gravity);
+
+    // In tool coordinates
+    Vector f(10,-20,30) ;
+    Vector n(3,-4,5) ;
+    Wrench f_tool(f,n);
+    // In local link coordinates
+    Wrenches f_ext(ns);
+    for(int i=0;i<ns;i++){
+        SetToZero(f_ext[i]);
+    }
+    f_ext[ns-1]=f_tool;
+
+    JntArray Tnoninertial(nj);
+    JntArray jntarraynull(nj);
+    SetToZero(jntarraynull);
+    IdSolver.CartToJnt(q, qd, jntarraynull, f_ext, Tnoninertial);
+    CPPUNIT_ASSERT(Equal(-21.252, Tnoninertial(0), eps));
+    CPPUNIT_ASSERT(Equal(-37.933, Tnoninertial(1), eps));
+    CPPUNIT_ASSERT(Equal(-2.497, Tnoninertial(2), eps));
+    CPPUNIT_ASSERT(Equal(-15.289, Tnoninertial(3), eps));
+    CPPUNIT_ASSERT(Equal(-4.646, Tnoninertial(4), eps));
+    CPPUNIT_ASSERT(Equal(-9.201, Tnoninertial(5), eps));
+    CPPUNIT_ASSERT(Equal(-5.249, Tnoninertial(6), eps));
+
+    // get acceleration using inverse symmetric matrix times vector
+    Eigen::MatrixXd H_eig(nj,nj), L(nj,nj);
+    Eigen::VectorXd Tnon_eig(nj), D(nj), r(nj), acc_eig(nj);
+    for(int i=0;i<nj;i++){
+        Tnon_eig(i) =  -Tnoninertial(i);
+        for(int j=0;j<nj;j++){
+            H_eig(i,j) =  H(i,j);
+        }
+    }
+    ldl_solver_eigen(H_eig, Tnon_eig, L, D, r, acc_eig);
+    for(int i=0;i<nj;i++){
+        qdd(i) = acc_eig(i);
+    }
+    CPPUNIT_ASSERT(Equal(2.998, qdd(0), eps));
+    CPPUNIT_ASSERT(Equal(4.289, qdd(1), eps));
+    CPPUNIT_ASSERT(Equal(0.946, qdd(2), eps));
+    CPPUNIT_ASSERT(Equal(2.518, qdd(3), eps));
+    CPPUNIT_ASSERT(Equal(3.530, qdd(4), eps));
+    CPPUNIT_ASSERT(Equal(8.150, qdd(5), eps));
+    CPPUNIT_ASSERT(Equal(4.254, qdd(6), eps));
+}
+
+void SolverTest::FdSolverConsistencyTest()
+{
+    int ret;
+    double eps=1.e-3;
+
+    std::cout<<"KDL FD Solver Consistency Test for Motoman SIA10"<<std::endl;
+
+    //  NOTE:  Compute the forward and inverse dynamics and test for consistency
+
+    //  Forward Dynamics Solver
+    Vector gravity(0.0, 0.0, -9.81);  // base frame
+    KDL::ChainFdSolver_RNE FdSolver = KDL::ChainFdSolver_RNE(motomansia10dyn, gravity);
+
+    unsigned int nj = motomansia10dyn.getNrOfJoints();
+    unsigned int ns = motomansia10dyn.getNrOfSegments();
+
+    // Joint position, velocity, and acceleration
+    KDL::JntArray q(nj);
+    KDL::JntArray qd(nj);
+    KDL::JntArray qdd(nj);
+    KDL::JntArray tau(nj);
+
+    //  random
+    q(0) = 0.2;
+    q(1) = 0.6;
+    q(2) = 1.;
+    q(3) = 0.5;
+    q(4) = -1.4;
+    q(5) = 0.3;
+    q(6) = -0.8;
+
+    qd(0) = 1.;
+    qd(1) = -2.;
+    qd(2) = 3.;
+    qd(3) = -4.;
+    qd(4) = 5.;
+    qd(5) = -6.;
+    qd(6) = 7.;
+
+    // actuator torques
+    tau(0) = 50.;
+    tau(1) = -20.;
+    tau(2) = 10.;
+    tau(3) = 40.;
+    tau(4) = -60.;
+    tau(5) = 15.;
+    tau(6) = -10.;
+
+    KDL::Vector f(10,-20,30) ;
+    KDL::Vector n(3,-4,5) ;
+    KDL::Wrench f_tool(f,n);
+    // In local link coordinates
+    KDL::Wrenches f_ext(ns);
+    for(int i=0;i<ns;i++){
+        SetToZero(f_ext[i]);
+    }
+    f_ext[ns-1]=f_tool;
+
+    // Call FD function
+    ret = FdSolver.CartToJnt(q, qd, tau, f_ext, qdd);
+    if (ret < 0) std::cout << "KDL: forward dynamics ERROR: " << ret << std::endl;
+    CPPUNIT_ASSERT(Equal(9.486, qdd(0), eps));
+    CPPUNIT_ASSERT(Equal(1.830, qdd(1), eps));
+    CPPUNIT_ASSERT(Equal(4.726, qdd(2), eps));
+    CPPUNIT_ASSERT(Equal(11.665, qdd(3), eps));
+    CPPUNIT_ASSERT(Equal(-50.108, qdd(4), eps));
+    CPPUNIT_ASSERT(Equal(21.403, qdd(5), eps));
+    CPPUNIT_ASSERT(Equal(-0.381, qdd(6), eps));
+
+    // Check against ID solver for consistency
+    KDL::ChainIdSolver_RNE IdSolver = KDL::ChainIdSolver_RNE(motomansia10dyn, gravity);
+    KDL::JntArray torque(nj);
+    IdSolver.CartToJnt(q, qd, qdd, f_ext, torque);
+    for ( int i=0; i<nj; i++ )
+    {
+        CPPUNIT_ASSERT(Equal(torque(i), tau(i), eps));
+    }
+
+    return;
 }

--- a/orocos_kdl/tests/solvertest.hpp
+++ b/orocos_kdl/tests/solvertest.hpp
@@ -18,6 +18,9 @@
 #include <chainidsolver_vereshchagin.hpp>
 #include <chainidsolver_recursive_newton_euler.hpp>
 #include <chaindynparam.hpp>
+#include <chainidsolver_recursive_newton_euler.hpp>
+#include <chainfdsolver_recursive_newton_euler.hpp>
+#include <utilities/ldl_solver_eigen.hpp>
 
 
 using namespace KDL;
@@ -34,6 +37,8 @@ class SolverTest : public CppUnit::TestFixture
     CPPUNIT_TEST(IkVelSolverWDLSTest );
     CPPUNIT_TEST(FkPosVectTest );
     CPPUNIT_TEST(FkVelVectTest );
+    CPPUNIT_TEST(FdSolverDevelopmentTest );
+    CPPUNIT_TEST(FdSolverConsistencyTest );
     CPPUNIT_TEST(UpdateChainTest );
     CPPUNIT_TEST_SUITE_END();
 
@@ -50,11 +55,13 @@ public:
     void IkVelSolverWDLSTest();
     void FkPosVectTest();
     void FkVelVectTest();
+    void FdSolverDevelopmentTest();
+    void FdSolverConsistencyTest();
     void UpdateChainTest();
 
 private:
 
-  Chain chain1,chain2,chain3,chain4, chaindyn,motomansia10;
+  Chain chain1, chain2, chain3, chain4, chaindyn, motomansia10, motomansia10dyn;
 
     void FkPosAndJacLocal(Chain& chain,ChainFkSolverPos& fksolverpos,ChainJntToJacSolver& jacsolver);
     void FkVelAndJacLocal(Chain& chain, ChainFkSolverVel& fksolvervel, ChainJntToJacSolver& jacsolver);

--- a/orocos_kdl/tests/solvertest.hpp
+++ b/orocos_kdl/tests/solvertest.hpp
@@ -39,6 +39,7 @@ class SolverTest : public CppUnit::TestFixture
     CPPUNIT_TEST(FkVelVectTest );
     CPPUNIT_TEST(FdSolverDevelopmentTest );
     CPPUNIT_TEST(FdSolverConsistencyTest );
+    CPPUNIT_TEST(LDLdecompTest);
     CPPUNIT_TEST(UpdateChainTest );
     CPPUNIT_TEST_SUITE_END();
 
@@ -57,6 +58,7 @@ public:
     void FkVelVectTest();
     void FdSolverDevelopmentTest();
     void FdSolverConsistencyTest();
+    void LDLdecompTest();
     void UpdateChainTest();
 
 private:


### PR DESCRIPTION
kdl solver: added chain forward dynamics solver

Created forward dynamics solver class based on inverse dynamics solver and inertia matrix from chaindynparam solver. In addition, a LDL solver function was added under the utilities to calculate the joint acceleration from the inertia matrix inverse times the joint torques.