### PR TITLE
New Tree features: sub-tree extraction and better tree printing

### DIFF
--- a/orocos_kdl/src/kinfam_io.cpp
+++ b/orocos_kdl/src/kinfam_io.cpp
@@ -21,6 +21,7 @@
 
 #include "kinfam_io.hpp"
 #include "frames_io.hpp"
+#include <string>
 
 namespace KDL {
 std::ostream& operator <<(std::ostream& os, const Joint& joint) {

--- a/orocos_kdl/src/kinfam_io.cpp
+++ b/orocos_kdl/src/kinfam_io.cpp
@@ -21,7 +21,7 @@
 
 #include "kinfam_io.hpp"
 #include "frames_io.hpp"
-#include <string>
+#include <sstream>
 
 namespace KDL {
 std::ostream& operator <<(std::ostream& os, const Joint& joint) {
@@ -115,13 +115,14 @@ std::istream& operator >>(std::istream& is, JntSpaceInertiaMatrix& jntspaceinert
 
 
 std::string tree2str(const SegmentMap::const_iterator it, const std::string& separator, const std::string& preamble, unsigned int level) {
-	std::string out = preamble;
+	std::stringstream out;
+	out << preamble;
 	for(unsigned int i=0; i<level; i++)
-		out += separator;
-	out += it->first + "(q_nr: " + std::to_string(GetTreeElementQNr(it->second)) + ")" + "\n";
+		out << separator;
+	out << it->first << "(q_nr: " << std::to_string(GetTreeElementQNr(it->second)) << ")\n";
 	for (unsigned int i = 0; i < GetTreeElementChildren(it->second).size(); i++)
-		out += tree2str(GetTreeElementChildren(it->second)[i], separator, preamble, level+1);
-	return out;
+		out << tree2str(GetTreeElementChildren(it->second)[i], separator, preamble, level+1);
+	return out.str();
 }
 
 std::string tree2str(const Tree& tree, const std::string& separator, const std::string& preamble) {

--- a/orocos_kdl/src/kinfam_io.cpp
+++ b/orocos_kdl/src/kinfam_io.cpp
@@ -111,5 +111,20 @@ std::ostream& operator <<(std::ostream& os, const JntSpaceInertiaMatrix& jntspac
 std::istream& operator >>(std::istream& is, JntSpaceInertiaMatrix& jntspaceinertiamatrix) {
 	return is;
 }
+
+
+std::string tree2str(const SegmentMap::const_iterator it, const std::string& separator, const std::string& preamble, unsigned int level) {
+	std::string out = preamble;
+	for(unsigned int i=0; i<level; i++)
+		out += separator;
+	out += it->first + "(q_nr: " + std::to_string(GetTreeElementQNr(it->second)) + ")" + "\n";
+	for (unsigned int i = 0; i < GetTreeElementChildren(it->second).size(); i++)
+		out += tree2str(GetTreeElementChildren(it->second)[i], separator, preamble, level+1);
+	return out;
 }
 
+std::string tree2str(const Tree& tree, const std::string& separator, const std::string& preamble) {
+	return tree2str(tree.getRootSegment(), separator, preamble, 0);
+}
+
+}

--- a/orocos_kdl/src/kinfam_io.cpp
+++ b/orocos_kdl/src/kinfam_io.cpp
@@ -119,7 +119,7 @@ std::string tree2str(const SegmentMap::const_iterator it, const std::string& sep
 	out << preamble;
 	for(unsigned int i=0; i<level; i++)
 		out << separator;
-	out << it->first << "(q_nr: " << std::to_string(GetTreeElementQNr(it->second)) << ")\n";
+	out << it->first << "(q_nr: " << GetTreeElementQNr(it->second) << ")\n";
 	for (unsigned int i = 0; i < GetTreeElementChildren(it->second).size(); i++)
 		out << tree2str(GetTreeElementChildren(it->second)[i], separator, preamble, level+1);
 	return out.str();

--- a/orocos_kdl/src/kinfam_io.hpp
+++ b/orocos_kdl/src/kinfam_io.hpp
@@ -53,6 +53,13 @@ std::istream& operator >>(std::istream& is, Jacobian& jac);
 std::ostream& operator <<(std::ostream& os, const JntSpaceInertiaMatrix& jntspaceinertiamatrix);
 std::istream& operator >>(std::istream& is, JntSpaceInertiaMatrix& jntspaceinertiamatrix);
 
+//Builds a string containing the "branches" of a Tree using indentation or another
+//user-supplied pattern, so that it is easier to visualize its structure. It is
+//also possible to specify a "preamble", ie, a string to be included at the
+//beginning of each new line.
+std::string tree2str(const Tree& tree, const std::string& separator="  ", const std::string& preamble="");
+std::string tree2str(const SegmentMap::const_iterator it, const std::string& separator="  ", const std::string& preamble="", unsigned int level=0);
+
     /*
 template<typename T>
 std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec) {
@@ -72,4 +79,3 @@ std::istream& operator >>(std::istream& is, std::vector<T>& vec) {
     */
 }
 #endif
-

--- a/orocos_kdl/src/tree.cpp
+++ b/orocos_kdl/src/tree.cpp
@@ -79,7 +79,7 @@ bool Tree::addSegment(const Segment& segment, const std::string& hook_name) {
         nrOfJoints++;
     return true;
 }
-    
+
 bool Tree::addChain(const Chain& chain, const std::string& hook_name) {
     string parent_name = hook_name;
     for (unsigned int i = 0; i < chain.getNrOfSegments(); i++) {
@@ -113,56 +113,65 @@ bool Tree::addTreeRecursive(SegmentMap::const_iterator root, const std::string& 
     }
     return true;
 }
-    
-    bool Tree::getChain(const std::string& chain_root, const std::string& chain_tip, Chain& chain)const
-    {
-        // clear chain
-        chain = Chain();
-        
-        // walk down from chain_root and chain_tip to the root of the tree
-        vector<SegmentMap::key_type> parents_chain_root, parents_chain_tip;
-        for (SegmentMap::const_iterator s=getSegment(chain_root); s!=segments.end(); s = GetTreeElementParent(s->second)){
-            parents_chain_root.push_back(s->first);
-            if (s->first == root_name) break;
-        }
-        if (parents_chain_root.empty() || parents_chain_root.back() != root_name) return false;
-        for (SegmentMap::const_iterator s=getSegment(chain_tip); s!=segments.end(); s = GetTreeElementParent(s->second)){
-            parents_chain_tip.push_back(s->first);
-            if (s->first == root_name) break;
-        }
-        if (parents_chain_tip.empty() || parents_chain_tip.back()  != root_name) return false;
-        
-        // remove common part of segment lists
-        SegmentMap::key_type last_segment = root_name;
-        while (!parents_chain_root.empty() && !parents_chain_tip.empty() &&
-               parents_chain_root.back() == parents_chain_tip.back()){
-            last_segment = parents_chain_root.back();
-            parents_chain_root.pop_back();
-            parents_chain_tip.pop_back();
-        }
-        parents_chain_root.push_back(last_segment);
-        
-        
-        // add the segments from the root to the common frame
-        for (unsigned int s=0; s<parents_chain_root.size()-1; s++){
-            Segment seg = GetTreeElementSegment(getSegment(parents_chain_root[s])->second);
-            Frame f_tip = seg.pose(0.0).Inverse();
-            Joint jnt = seg.getJoint();
-            if (jnt.getType() == Joint::RotX || jnt.getType() == Joint::RotY || jnt.getType() == Joint::RotZ || jnt.getType() == Joint::RotAxis)
-	      jnt = Joint(jnt.getName(), f_tip*jnt.JointOrigin(), f_tip.M*(-jnt.JointAxis()), Joint::RotAxis);
-	    else if (jnt.getType() == Joint::TransX || jnt.getType() == Joint::TransY || jnt.getType() == Joint::TransZ || jnt.getType() == Joint::TransAxis)
-	      jnt = Joint(jnt.getName(),f_tip*jnt.JointOrigin(), f_tip.M*(-jnt.JointAxis()), Joint::TransAxis);
-        chain.addSegment(Segment(GetTreeElementSegment(getSegment(parents_chain_root[s+1])->second).getName(),
-                                     jnt, f_tip, GetTreeElementSegment(getSegment(parents_chain_root[s+1])->second).getInertia()));
-        }
-        
-        // add the segments from the common frame to the tip frame
-        for (int s=parents_chain_tip.size()-1; s>-1; s--){
-            chain.addSegment(GetTreeElementSegment(getSegment(parents_chain_tip[s])->second));
-        }
-        return true;
+
+bool Tree::getChain(const std::string& chain_root, const std::string& chain_tip, Chain& chain)const
+{
+    // clear chain
+    chain = Chain();
+
+    // walk down from chain_root and chain_tip to the root of the tree
+    vector<SegmentMap::key_type> parents_chain_root, parents_chain_tip;
+    for (SegmentMap::const_iterator s=getSegment(chain_root); s!=segments.end(); s = GetTreeElementParent(s->second)){
+        parents_chain_root.push_back(s->first);
+        if (s->first == root_name) break;
     }
-    
+    if (parents_chain_root.empty() || parents_chain_root.back() != root_name) return false;
+    for (SegmentMap::const_iterator s=getSegment(chain_tip); s!=segments.end(); s = GetTreeElementParent(s->second)){
+        parents_chain_tip.push_back(s->first);
+        if (s->first == root_name) break;
+    }
+    if (parents_chain_tip.empty() || parents_chain_tip.back()  != root_name) return false;
+
+    // remove common part of segment lists
+    SegmentMap::key_type last_segment = root_name;
+    while (!parents_chain_root.empty() && !parents_chain_tip.empty() &&
+           parents_chain_root.back() == parents_chain_tip.back()){
+        last_segment = parents_chain_root.back();
+        parents_chain_root.pop_back();
+        parents_chain_tip.pop_back();
+    }
+    parents_chain_root.push_back(last_segment);
+
+
+    // add the segments from the root to the common frame
+    for (unsigned int s=0; s<parents_chain_root.size()-1; s++){
+        Segment seg = GetTreeElementSegment(getSegment(parents_chain_root[s])->second);
+        Frame f_tip = seg.pose(0.0).Inverse();
+        Joint jnt = seg.getJoint();
+        if (jnt.getType() == Joint::RotX || jnt.getType() == Joint::RotY || jnt.getType() == Joint::RotZ || jnt.getType() == Joint::RotAxis)
+    jnt = Joint(jnt.getName(), f_tip*jnt.JointOrigin(), f_tip.M*(-jnt.JointAxis()), Joint::RotAxis);
+  else if (jnt.getType() == Joint::TransX || jnt.getType() == Joint::TransY || jnt.getType() == Joint::TransZ || jnt.getType() == Joint::TransAxis)
+    jnt = Joint(jnt.getName(),f_tip*jnt.JointOrigin(), f_tip.M*(-jnt.JointAxis()), Joint::TransAxis);
+    chain.addSegment(Segment(GetTreeElementSegment(getSegment(parents_chain_root[s+1])->second).getName(),
+                                 jnt, f_tip, GetTreeElementSegment(getSegment(parents_chain_root[s+1])->second).getInertia()));
+    }
+
+    // add the segments from the common frame to the tip frame
+    for (int s=parents_chain_tip.size()-1; s>-1; s--){
+        chain.addSegment(GetTreeElementSegment(getSegment(parents_chain_tip[s])->second));
+    }
+    return true;
+}
+
+bool Tree::getSubTree(const std::string& segment_name, Tree& tree) const
+{
+  //check if segment_name exists
+  SegmentMap::const_iterator root = segments.find(segment_name);
+  if (root == segments.end())
+    return false;
+  //init the tree, segment_name is the new root.
+  tree = Tree(root->first);
+  return tree.addTreeRecursive(root, segment_name);
+}
+
 }//end of namespace
-
-

--- a/orocos_kdl/src/tree.hpp
+++ b/orocos_kdl/src/tree.hpp
@@ -129,7 +129,7 @@ namespace KDL
 
         /**
          * Adds a complete chain to the end of the segment with
-         * hook_name as segment_name. 
+         * hook_name as segment_name.
          *
          * @param hook_name name of the segment to connect the chain with.
          *
@@ -139,7 +139,7 @@ namespace KDL
 
         /**
          * Adds a complete tree to the end of the segment with
-         * hookname as segment_name. 
+         * hookname as segment_name.
          *
          * @param tree Tree to add
          * @param hook_name name of the segment to connect the tree with
@@ -188,19 +188,32 @@ namespace KDL
           return segments.find(root_name);
         };
 
-        /**
-         * Request the chain of the tree between chain_root and chain_tip.  The chain_root
-         * and chain_tip can be in different branches of the tree, the chain_root can be
-         * an ancestor of chain_tip, and chain_tip can be an ancestor of chain_root.
-         *
-         * @param chain_root the name of the root segment of the chain
-         * @param chain_tip the name of the tip segment of the chain
-         * @param chain the resulting chain
-         *
-         * @return success or failure
-         */
-      bool getChain(const std::string& chain_root, const std::string& chain_tip, Chain& chain)const;
+          /**
+           * Request the chain of the tree between chain_root and chain_tip.  The chain_root
+           * and chain_tip can be in different branches of the tree, the chain_root can be
+           * an ancestor of chain_tip, and chain_tip can be an ancestor of chain_root.
+           *
+           * @param chain_root the name of the root segment of the chain
+           * @param chain_tip the name of the tip segment of the chain
+           * @param chain the resulting chain
+           *
+           * @return success or failure
+           */
+        bool getChain(const std::string& chain_root, const std::string& chain_tip, Chain& chain)const;
 
+
+
+          /**
+           * Extract a tree having segment_name as root. Only child segments of
+           * segment_name are added to the new tree.
+           *
+           * @param segment_name the name of the segment to be used as root
+           * of the new tree
+           * @param tree the resulting sub-tree
+           *
+           * @return success or failure
+           */
+        bool getSubTree(const std::string& segment_name, Tree& tree)const;
 
         const SegmentMap& getSegments()const
         {
@@ -212,8 +225,3 @@ namespace KDL
     };
 }
 #endif
-
-
-
-
-

--- a/orocos_kdl/tests/kinfamtest.cpp
+++ b/orocos_kdl/tests/kinfamtest.cpp
@@ -155,6 +155,9 @@ void KinFamTest::ChainTest()
     CPPUNIT_ASSERT_EQUAL(chain2.getNrOfSegments(),chain1.getNrOfSegments()*(uint)2);
 }
 
+// forward declaration, see below
+bool isSubtree(const SegmentMap::const_iterator container, const SegmentMap::const_iterator contained);
+
 void KinFamTest::TreeTest()
 {
     Tree tree1;
@@ -225,7 +228,46 @@ void KinFamTest::TreeTest()
     solver1.JntToCart(jnt1, f1);
     solver2.JntToCart(jnt2, f2);
     CPPUNIT_ASSERT(f1 == f2.Inverse());
+
+    Tree subtree;
+    const std::string subroot("Segment 2");
+    CPPUNIT_ASSERT(tree1.getSubTree(subroot, subtree));
+    cout << "Tree 1:" << endl << tree1 << endl;
+    cout << "Subtree (rooted at " << subroot << "):" << endl << subtree << endl;
+    CPPUNIT_ASSERT(isSubtree(tree1.getSegment(subroot), subtree.getRootSegment()));
+    CPPUNIT_ASSERT(isSubtree(subtree.getRootSegment(), tree1.getSegment(subroot)));
+
+    Segment segment101("Segment 101", Joint("Joint 101", Joint::RotZ), Frame(Vector(0.0,0.0,0.5)));
+    Segment segment102("Segment 102", Joint("Joint 102", Joint::RotZ), Frame(Vector(0.0,0.0,1.0)));
+    subtree.addSegment(segment101, subtree.getRootSegment()->first);
+    subtree.addSegment(segment102, subtree.getSegment("Segment 5")->first);
+    cout << "Subtree (rooted at " << subroot << "):" << endl << subtree << endl;
+    CPPUNIT_ASSERT(!isSubtree(tree1.getSegment(subroot), subtree.getRootSegment()));
+    CPPUNIT_ASSERT(isSubtree(subtree.getRootSegment(), tree1.getSegment(subroot)));
 }
 
-
-
+//Utility to check if the set of segments in contained is a subset of container.
+//In addition, all the children of a segment in contained must be present in
+//container as children of the same segment.
+bool isSubtree(const SegmentMap::const_iterator container, const SegmentMap::const_iterator contained) {
+    //Check that the container and contained point to the same link
+    if(container->first != contained->first)
+        return false;
+    //Check that each child of contained is a child of container
+    std::vector<SegmentMap::const_iterator> children = GetTreeElementChildren(contained->second);
+    for(unsigned int i=0; i < children.size(); i++) {
+        //look for a child of container whose name matches the one of the current child from contained
+        std::vector<SegmentMap::const_iterator>::const_iterator it = GetTreeElementChildren(container->second).begin();
+        while(it != GetTreeElementChildren(container->second).end()) {
+            if((*it)->first == children[i]->first)
+                break; //segment found, exit the loop
+            it++;
+        }
+        if(it == GetTreeElementChildren(container->second).end())
+            return false; //child of contained not found as child of container
+        //inspect recursively all the children
+        if(!isSubtree((*it), children[i]))
+            return false;
+    }
+    return true;
+}

--- a/orocos_kdl/tests/kinfamtest.cpp
+++ b/orocos_kdl/tests/kinfamtest.cpp
@@ -209,7 +209,7 @@ void KinFamTest::TreeTest()
 
     Chain extract_chain1;
     CPPUNIT_ASSERT(tree1.getChain("Segment 2", "Segment 4", extract_chain1));
-    Chain extract_chain2; 
+    Chain extract_chain2;
     CPPUNIT_ASSERT(tree1.getChain("Segment 4", "Segment 2", extract_chain2));
     CPPUNIT_ASSERT(tree1.getChain("Segment 4", "Segment 2", extract_chain2));
     CPPUNIT_ASSERT(extract_chain1.getNrOfJoints()==extract_chain2.getNrOfJoints());
@@ -232,8 +232,8 @@ void KinFamTest::TreeTest()
     Tree subtree;
     const std::string subroot("Segment 2");
     CPPUNIT_ASSERT(tree1.getSubTree(subroot, subtree));
-    cout << "Tree 1:" << endl << tree1 << endl;
-    cout << "Subtree (rooted at " << subroot << "):" << endl << subtree << endl;
+    cout << "Tree 1:" << endl << tree2str(tree1) << endl;
+    cout << "Subtree (rooted at " << subroot << "):" << endl << tree2str(subtree) << endl;
     CPPUNIT_ASSERT(isSubtree(tree1.getSegment(subroot), subtree.getRootSegment()));
     CPPUNIT_ASSERT(isSubtree(subtree.getRootSegment(), tree1.getSegment(subroot)));
 
@@ -241,7 +241,7 @@ void KinFamTest::TreeTest()
     Segment segment102("Segment 102", Joint("Joint 102", Joint::RotZ), Frame(Vector(0.0,0.0,1.0)));
     subtree.addSegment(segment101, subtree.getRootSegment()->first);
     subtree.addSegment(segment102, subtree.getSegment("Segment 5")->first);
-    cout << "Subtree (rooted at " << subroot << "):" << endl << subtree << endl;
+    cout << "Subtree (rooted at " << subroot << "):" << endl << tree2str(subtree) << endl;
     CPPUNIT_ASSERT(!isSubtree(tree1.getSegment(subroot), subtree.getRootSegment()));
     CPPUNIT_ASSERT(isSubtree(subtree.getRootSegment(), tree1.getSegment(subroot)));
 }


### PR DESCRIPTION
The two commits introduce one new feature each:

1. A new public method `Tree::getSubTree(const string& segment_name, Tree& tree)`. This allows to extract from the original object a new tree that starts at `segment_name` and includes all its children.

2. Two functions `tree2str` (see [kinfam_io.hpp](https://github.com/francofusco/orocos_kinematics_dynamics/blob/new_tree_features/orocos_kdl/src/kinfam_io.hpp)) which return a string representing a tree. In my opinion they provide a better and clearer output than `operator<<(ostream&, Tree&)` thanks to the use of indentation.