### PR TITLE
[Windows] Fix SIPMacros.cmake for Windows build.

### DIFF
--- a/python_orocos_kdl/cmake/SIPMacros.cmake
+++ b/python_orocos_kdl/cmake/SIPMacros.cmake
@@ -92,20 +92,10 @@ MACRO(ADD_SIP_PYTHON_MODULE MODULE_NAME MODULE_SIP)
         ENDIF( ${CONCAT_NUM} LESS ${SIP_CONCAT_PARTS} )
     ENDFOREACH(CONCAT_NUM RANGE 0 ${SIP_CONCAT_PARTS} )
 
-    IF(NOT WIN32)
-        SET(TOUCH_COMMAND touch)
-    ELSE(NOT WIN32)
-        SET(TOUCH_COMMAND echo)
-        # instead of a touch command, give out the name and append to the files
-        # this is basically what the touch command does.
-        FOREACH(filename ${_sip_output_files})
-            FILE(APPEND filename "")
-        ENDFOREACH(filename ${_sip_output_files})
-    ENDIF(NOT WIN32)
     ADD_CUSTOM_COMMAND(
         OUTPUT ${_sip_output_files} 
         COMMAND ${CMAKE_COMMAND} -E echo ${message}
-        COMMAND ${TOUCH_COMMAND} ${_sip_output_files} 
+        COMMAND ${CMAKE_COMMAND} -E touch ${_sip_output_files}
         COMMAND ${SIP_EXECUTABLE} ${_sip_tags} ${_sip_x} ${SIP_EXTRA_OPTIONS} -j ${SIP_CONCAT_PARTS} -c ${CMAKE_CURRENT_SIP_OUTPUT_DIR} ${_sip_includes} ${_abs_module_sip}
         DEPENDS ${_abs_module_sip} ${SIP_EXTRA_FILES_DEPEND}
     )


### PR DESCRIPTION
### Background
SIP takes .sip to generate C++ code to build native Python binding module, and SIP_CONCAT_PARTS decides how many C++ files to generate for parallel build. And since it doesn't know how many parts SIP actually created in Cmake configuration time, it emits command to generate the stub C++ files in case they are not there.

### Problem
The "touch" implementation seems to be broken on Windows. It is generating a file called "filename" under the current directory, instead of touching and creating the stub files.

### Solution
Instead of special handling the touch commands for Windows, replace the logic with a more generic "COMMAND ${CMAKE_COMMAND} -E touch ${_sip_output_files}" to be cross platform.

(This is verified on **ROS on Windows** project. https://aka.ms/ros)