### PR TITLE
fix build for missing isnan definition in newer compilers

### DIFF
--- a/orocos_kdl/src/utilities/utility.h
+++ b/orocos_kdl/src/utilities/utility.h
@@ -127,9 +127,9 @@ namespace KDL {
     }
 #endif  
 
-
-
-
+#if (__cplusplus > 199711L)
+using std::isnan;
+#endif
 
 /** 
  * Auxiliary class for argument types (Trait-template class )


### PR DESCRIPTION
With newer compiler versions (such as clang 7 which Travis has recently started using by default), the standard `cmath` header undefines the global C `isnan` function declaration, which means that we need to use `std::isnan` in those cases. One would expect both definitions to always be available, but apparently, [this is not the case](https://developers.redhat.com/blog/2016/02/29/why-cstdlib-is-more-complicated-than-you-might-think/).
The utility header was updated to use `std::isnan` when `isnan` is called from the `KDL` namespace, if available (i.e., when building using C++11 or newer). This solves the issue in a forward-compatible manner.