### PR TITLE
Joint: getDamping() & getStiffness()

### DIFF
--- a/orocos_kdl/src/joint.hpp
+++ b/orocos_kdl/src/joint.hpp
@@ -202,6 +202,26 @@ namespace KDL {
             return inertia;
         };
 
+        /**
+         * Request the damping of the joint.
+         *
+         * @return const reference to the damping of the joint
+         */
+        const double& getDamping() const
+        {
+            return damping;
+        };
+
+        /**
+         * Request the stiffness of the joint.
+         *
+         * @return const reference to the stiffness of the joint
+         */
+        const double& getStiffness() const
+        {
+            return stiffness;
+        };
+
         virtual ~Joint();
 
     private:

--- a/python_orocos_kdl/PyKDL/kinfam.sip
+++ b/python_orocos_kdl/PyKDL/kinfam.sip
@@ -132,6 +132,9 @@ public:
     Vector JointAxis() const /Factory/;
     Vector JointOrigin() const /Factory/;
     std::string getName()const;
+    const double& getInertia()const;
+    const double& getDamping()const;
+    const double& getStiffness()const;
 
     JointType getType() const;
     std::string getTypeName() const;


### PR DESCRIPTION
The `Joint` class has inaccessible private properties `damping` and `stiffness`. This PR adds the accessors `getDamping` and `getStiffness` to retrieve a constant reference to these values. The same are also added to PyKDL.