### PR TITLE
Simplify implementation of addDelta() for rotations

### DIFF
--- a/orocos_kdl/src/frames.inl
+++ b/orocos_kdl/src/frames.inl
@@ -1151,7 +1151,7 @@ IMETHOD Vector addDelta(const Vector& a,const Vector&da,double dt) {
 }
 
 IMETHOD Rotation addDelta(const Rotation& a,const Vector&da,double dt) {
-	return a*Rot(a.Inverse(da)*dt);
+	return Rot(da*dt)*a;
 }
 IMETHOD Frame addDelta(const Frame& a,const Twist& da,double dt) {
 	return Frame(

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -506,60 +506,107 @@ void FramesTest::TestQuaternion() {
 	CPPUNIT_ASSERT_DOUBLES_EQUAL(w, w2, epsilon);
 }
 
+void FramesTest::TestOneRotationDiff(
+        const std::string& msg,
+        const Rotation& R_a_b1,
+        const Rotation& R_a_b2,
+        const Vector& expectedDiff) {
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, diff(R_a_b1, R_a_b2), expectedDiff);
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(msg, addDelta(R_a_b1, expectedDiff), R_a_b2);
+}
 
 void FramesTest::TestRotationDiff() {
 
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(0*deg2rad)), Vector(0,0,0));		// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(90*deg2rad)), Vector(M_PI/2,0,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(180*deg2rad)), Vector(M_PI,0,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(270*deg2rad)), Vector(-M_PI/2,0,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(360*deg2rad)), Vector(0,0,0));		// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(-360*deg2rad)), Vector(0,0,0));	// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(-270*deg2rad)), Vector(M_PI/2,0,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(-180*deg2rad)), Vector(M_PI,0,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(-90*deg2rad)), Vector(-M_PI/2,0,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotX(-0*deg2rad)), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(0*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(0*deg2rad), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(90*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(90*deg2rad), Vector(M_PI/2,0,0));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(180*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(180*deg2rad), Vector(M_PI,0,0));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(270*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(270*deg2rad), Vector(-M_PI/2,0,0));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(360*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(360*deg2rad), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(-360*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(-360*deg2rad), Vector(0,0,0));	// no rotation
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(-270*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(-270*deg2rad), Vector(M_PI/2,0,0));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(-180*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(-180*deg2rad), Vector(M_PI,0,0));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(-90*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(-90*deg2rad), Vector(-M_PI/2,0,0));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotX(-0*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotX(-0*deg2rad), Vector(0,0,0));		// no rotation
 
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(0*deg2rad)), Vector(0,0,0));		// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(90*deg2rad)), Vector(0,M_PI/2,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(180*deg2rad)), Vector(0,M_PI,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(270*deg2rad)), Vector(0,-M_PI/2,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(360*deg2rad)), Vector(0,0,0));		// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(-360*deg2rad)), Vector(0,0,0));	// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(-270*deg2rad)), Vector(0,M_PI/2,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(-180*deg2rad)), Vector(0,M_PI,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(-90*deg2rad)), Vector(0,-M_PI/2,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotY(-0*deg2rad)), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(0*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(0*deg2rad), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(90*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(90*deg2rad), Vector(0,M_PI/2,0));
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(180*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(180*deg2rad), Vector(0,M_PI,0));
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(270*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(270*deg2rad), Vector(0,-M_PI/2,0));
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(360*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(360*deg2rad), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(-360*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(-360*deg2rad), Vector(0,0,0));	// no rotation
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(-270*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(-270*deg2rad), Vector(0,M_PI/2,0));
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(-180*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(-180*deg2rad), Vector(0,M_PI,0));
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(-90*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(-90*deg2rad), Vector(0,-M_PI/2,0));
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotY(-0*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotY(-0*deg2rad), Vector(0,0,0));		// no rotation
 
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(0*deg2rad)), Vector(0,0,0));		// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(90*deg2rad)), Vector(0,0,M_PI/2));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(180*deg2rad)), Vector(0,0,M_PI));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(270*deg2rad)), Vector(0,0,-M_PI/2));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(360*deg2rad)), Vector(0,0,0));		// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(-360*deg2rad)), Vector(0,0,0));	// no rotation
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(-270*deg2rad)), Vector(0,0,M_PI/2));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(-180*deg2rad)), Vector(0,0,M_PI));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(-90*deg2rad)), Vector(0,0,-M_PI/2));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotZ(0*deg2rad), Rotation::RotZ(-0*deg2rad)), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(0*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(0*deg2rad), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(90*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(90*deg2rad), Vector(0,0,M_PI/2));
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(180*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(180*deg2rad), Vector(0,0,M_PI));
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(270*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(270*deg2rad), Vector(0,0,-M_PI/2));
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(360*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(360*deg2rad), Vector(0,0,0));		// no rotation
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(-360*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(-360*deg2rad), Vector(0,0,0));	// no rotation
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(-270*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(-270*deg2rad), Vector(0,0,M_PI/2));
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(-180*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(-180*deg2rad), Vector(0,0,M_PI));
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(-90*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(-90*deg2rad), Vector(0,0,-M_PI/2));
+    TestOneRotationDiff("diff(RotZ(0*deg2rad),RotZ(-0*deg2rad))",
+        Rotation::RotZ(0*deg2rad), Rotation::RotZ(-0*deg2rad), Vector(0,0,0));		// no rotation
 
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotZ(90*deg2rad)), Vector(0,0,M_PI/2));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotX(0*deg2rad), Rotation::RotY(90*deg2rad)), Vector(0,M_PI/2,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RotY(0*deg2rad), Rotation::RotZ(90*deg2rad)), Vector(0,0,M_PI/2));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotZ(90*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotZ(90*deg2rad), Vector(0,0,M_PI/2));
+    TestOneRotationDiff("diff(RotX(0*deg2rad),RotY(90*deg2rad))",
+        Rotation::RotX(0*deg2rad), Rotation::RotY(90*deg2rad), Vector(0,M_PI/2,0));
+    TestOneRotationDiff("diff(RotY(0*deg2rad),RotZ(90*deg2rad))",
+        Rotation::RotY(0*deg2rad), Rotation::RotZ(90*deg2rad), Vector(0,0,M_PI/2));
 
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::Identity(), Rotation::RotX(90*deg2rad)), Vector(M_PI/2,0,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::Identity(), Rotation::RotY(90*deg2rad)), Vector(0,M_PI/2,0));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::Identity(), Rotation::RotZ(90*deg2rad)), Vector(0,0,M_PI/2));
+    TestOneRotationDiff("diff(Identity(),RotX(90*deg2rad))",
+        Rotation::Identity(), Rotation::RotX(90*deg2rad), Vector(M_PI/2,0,0));
+    TestOneRotationDiff("diff(Identity(),RotY(0*deg2rad))",
+        Rotation::Identity(), Rotation::RotY(90*deg2rad), Vector(0,M_PI/2,0));
+    TestOneRotationDiff("diff(Identity(),RotZ(0*deg2rad))",
+        Rotation::Identity(), Rotation::RotZ(90*deg2rad), Vector(0,0,M_PI/2));
 
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RPY(+0*deg2rad,0,-90*deg2rad),
-								   Rotation::RPY(-0*deg2rad,0,+90*deg2rad)),
-						 Vector(0,0,M_PI));
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(Rotation::RPY(+5*deg2rad,0,-0*deg2rad),
-								   Rotation::RPY(-5*deg2rad,0,+0*deg2rad)),
-						 Vector(-10*deg2rad,0,0));
+    TestOneRotationDiff("diff(Rotation::RPY(+0*deg2rad,0,-90*deg2rad),Rotation::RPY(-0*deg2rad,0,+90*deg2rad))",
+        Rotation::RPY(+0*deg2rad,0,-90*deg2rad),
+        Rotation::RPY(-0*deg2rad,0,+90*deg2rad),
+        Vector(0,0,M_PI));
+    TestOneRotationDiff("diff(Rotation::RPY(+5*deg2rad,0,-0*deg2rad),Rotation::RPY(-5*deg2rad,0,+0*deg2rad))",
+        Rotation::RPY(+5*deg2rad,0,-0*deg2rad),
+        Rotation::RPY(-5*deg2rad,0,+0*deg2rad),
+        Vector(-10*deg2rad,0,0));
 
     KDL::Rotation R1 = Rotation::RPY(+5*deg2rad,0,-90*deg2rad);
-	CPPUNIT_ASSERT_EQUAL(KDL::diff(R1, Rotation::RPY(-5*deg2rad,0,+90*deg2rad)),
-						           R1*Vector(0, 0, 180*deg2rad));
+    TestOneRotationDiff("diff(Rotation::RPY(+5*deg2rad,0,-90*deg2rad),Rotation::RPY(-5*deg2rad,0,+90*deg2rad))",
+        R1, Rotation::RPY(-5*deg2rad,0,+90*deg2rad),
+        R1*Vector(0, 0, 180*deg2rad));
 }
 
 void FramesTest::TestFrame() {

--- a/orocos_kdl/tests/framestest.hpp
+++ b/orocos_kdl/tests/framestest.hpp
@@ -57,6 +57,10 @@ private:
     void TestRangeArbitraryRotation(const std::string& msg,
                                     const KDL::Vector& v,
                                     const KDL::Vector& expectedVector);
+    void TestOneRotationDiff(const std::string& msg,
+                             const KDL::Rotation& R_a_b1,
+                             const KDL::Rotation& R_a_b2,
+                             const KDL::Vector& expectedDiff);
  
 };
 


### PR DESCRIPTION
`Rot(M*x) == M*Rot(x)*M^T` for any rotation matrix `M` and vector x, where `Rot(x)` returns the rotation matrix that corresponds to rotation vector `x` according to the [Rodrigues rotation formula](https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula), as implemented in [Rot()](https://github.com/orocos/orocos_kinematics_dynamics/blob/1ae45bb2e0821586e74047b01f7cb48d913204f4/orocos_kdl/src/frames.inl#L1095-L1121).

So the expression

    a*Rot(a.Inverse(da)*dt)

in `addDelta(const Rotation& a,const Vector&da, double dt)` can be simplified as

    = a*Rot(a.Inverse()*da*dt)
    = a*a.Inverse()*Rot(da*dt)*a
    = Rot(da*dt)*a

which saves one matrix multiplication.