### PR TITLE
back to use a more numerically stable method to compute the rotation angle

### DIFF
--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -416,12 +416,12 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
     // If the matrix is slightly non-orthogonal, `f` may be out of the (-1, +1) range.
     // Therefore, clamp it between those values to avoid NaNs.
     double f = (data[0] + data[4] + data[8] - 1) / 2;
-    angle = acos(std::max(-1.0, std::min(1.0, f)));
 
     x = (data[7] - data[5]);
     y = (data[2] - data[6]);
     z = (data[3] - data[1]);
     axis = KDL::Vector(x, y, z);
+    angle = atan2(axis.Norm()/2,f);
     axis.Normalize();
     return angle;
 }

--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -413,8 +413,6 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
         return angle; // return 180 deg rotation
     }
 
-    // If the matrix is slightly non-orthogonal, `f` may be out of the (-1, +1) range.
-    // Therefore, clamp it between those values to avoid NaNs.
     double f = (data[0] + data[4] + data[8] - 1) / 2;
 
     x = (data[7] - data[5]);


### PR DESCRIPTION
This PR is related to the recent 1.3.2 release.

When I used KDL to compute a very precise ik solution (eps = 1e-6 or 1e-7), the `angle = acos()` in `Rotation::GetRotAngle(Vector& axis,double eps)` can not provide a highly accurate rotation angle, which can cause ik fail. According to https://en.wikipedia.org/wiki/Axis%E2%80%93angle_representation, the previous `angle = atan2()` method is more numerically stable. 

After I switched to `angle=atan2()`, the succeed rate increased a lot. 