### PR TITLE
Correct return code of PyKDL test

### DIFF
--- a/python_orocos_kdl/tests/PyKDLtest.py
+++ b/python_orocos_kdl/tests/PyKDLtest.py
@@ -24,9 +24,16 @@ import kinfamtest
 import framestest
 import frameveltest
 
+import sys
+
 suite = unittest.TestSuite()
 suite.addTest(framestest.suite())
 suite.addTest(frameveltest.suite())
 suite.addTest(kinfamtest.suite())
 
-unittest.TextTestRunner(verbosity=3).run(suite)
+result = unittest.TextTestRunner(verbosity=3).run(suite)
+
+if result.wasSuccessful():
+    sys.exit(0)
+else:
+    sys.exit(1)


### PR DESCRIPTION
PyKDL test will now return a correct return code. So if the test fails, travis recognizes this.