### PR TITLE
Fix build warnings in gcc 9.2.1

### DIFF
--- a/orocos_kdl/src/frames.hpp
+++ b/orocos_kdl/src/frames.hpp
@@ -310,8 +310,9 @@ public:
                 double Xy,double Yy,double Zy,
                 double Xz,double Yz,double Zz);
     inline Rotation(const Vector& x,const Vector& y,const Vector& z);
-    // default copy constructor is sufficient
 
+    // default copy constructor is sufficient
+    constexpr Rotation(const Rotation&) = default;
 
      inline Rotation& operator=(const Rotation& arg);
 
@@ -1059,6 +1060,9 @@ public:
     explicit Rotation2(double angle_rad):s(sin(angle_rad)),c(cos(angle_rad)) {}
 
     Rotation2(double ca,double sa):s(sa),c(ca){}
+
+    // default copy constructor is sufficient
+    constexpr Rotation2(const Rotation2&) = default;
 
      inline Rotation2& operator=(const Rotation2& arg);
      inline Vector2 operator*(const Vector2& v) const;

--- a/orocos_kdl/src/frames.hpp
+++ b/orocos_kdl/src/frames.hpp
@@ -311,8 +311,7 @@ public:
                 double Xz,double Yz,double Zz);
     inline Rotation(const Vector& x,const Vector& y,const Vector& z);
 
-    // default copy constructor is sufficient
-    constexpr Rotation(const Rotation&) = default;
+    inline Rotation(const Rotation& arg);
 
      inline Rotation& operator=(const Rotation& arg);
 
@@ -1061,8 +1060,7 @@ public:
 
     Rotation2(double ca,double sa):s(sa),c(ca){}
 
-    // default copy constructor is sufficient
-    constexpr Rotation2(const Rotation2&) = default;
+    Rotation2(const Rotation2& arg);
 
      inline Rotation2& operator=(const Rotation2& arg);
      inline Vector2 operator*(const Vector2& v) const;

--- a/orocos_kdl/src/frames.inl
+++ b/orocos_kdl/src/frames.inl
@@ -512,6 +512,11 @@ Rotation::Rotation(const Vector& x,const Vector& y,const Vector& z)
     data[2] = z.data[0];data[5] = z.data[1];data[8] = z.data[2];
 }
 
+Rotation::Rotation(const Rotation& arg) {
+    int count=9;
+    while (count--) data[count] = arg.data[count];
+}
+
 Rotation& Rotation::operator=(const Rotation& arg) {
     int count=9;
     while (count--) data[count] = arg.data[count];
@@ -839,7 +844,9 @@ IMETHOD void Vector2::Set3DPlane(const Frame& F_someframe_XY,const Vector& v_som
     data[1]=tmp(1);
 }
 
-
+IMETHOD Rotation2::Rotation2(const Rotation2& arg) {
+    c=arg.c;s=arg.s;
+}
 
 IMETHOD Rotation2& Rotation2::operator=(const Rotation2& arg) {
     c=arg.c;s=arg.s;


### PR DESCRIPTION
I got those warnings in the [ros2 fork](https://github.com/ros2/orocos_kinematics_dynamics).
Here an example of them:
https://ci.ros2.org/job/ci_linux/9200/warnings23Result/package.274912723/