### PR TITLE
added a test for the memory leak in Tree.getChain from #211

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 
 before_script:
   - sudo apt-get -qq update
-  - sudo apt-get install -y libeigen3-dev libcppunit-dev python-sip-dev
+  - sudo apt-get install -y libeigen3-dev libcppunit-dev python-sip-dev python-psutil
   #build orocos_kdl
   - cd orocos_kdl
   - mkdir build

--- a/python_orocos_kdl/package.xml
+++ b/python_orocos_kdl/package.xml
@@ -18,6 +18,8 @@
   <run_depend>orocos_kdl</run_depend>
   <run_depend>python-sip</run_depend>
 
+  <test_depend>python-psutil</test_depend>
+
   <export>
     <build_type>cmake</build_type>
   </export>


### PR DESCRIPTION
Checks that a sequence of getChain calls does not increase the memory usage.

I am not sure what the test dependency on python-psutil will break on some build systems, but it seems to be the recommended os independent way to get the memory usage.