### PR TITLE
python_orocos_kdl requires orocos_kdl

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -5,7 +5,7 @@ endif()
 
 project(python_orocos_kdl)
 
-find_package(orocos_kdl)
+find_package(orocos_kdl REQUIRED)
 include_directories(${orocos_kdl_INCLUDE_DIRS})
 link_directories(${orocos_kdl_LIBRARY_DIRS})
 


### PR DESCRIPTION
Noticed by @cottsay. Adds `REQUIRED` so CMake fails at configure time rather than build time.