### PR TITLE
(PyKDL) add (deep)copy test functions

### DIFF
--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -414,6 +414,31 @@ class FramesTestFunctions(unittest.TestCase):
 
         self.assertEqual(data, data1)
 
+    def testCopyImpl(self, copy):
+        v1 = Vector(1, 2, 3)
+        v2 = copy(v1)
+        self.assertEqual(v1, v2)
+        r1 = Rotation().EulerZYZ(1, 2, 3)
+        r2 = copy(r1)
+        self.assertEqual(r1, r2)
+        f1 = Frame(r1, v1)
+        f2 = copy(f1)
+        self.assertEqual(f1, f2)
+        t1 = Twist(v1, Vector(4, 5, 6))
+        t2 = copy(t1)
+        self.assertEqual(t1, t2)
+        w1 = Wrench(Vector(0.1, 0.2, 0.3), v1)
+        w2 = copy(w1)
+        self.assertEqual(w1, w2)
+
+    def testCopy(self):
+        from copy import copy
+        self.testCopyImpl(copy)
+
+    def testDeepCopy(self):
+        from copy import deepcopy
+        self.testCopyImpl(deepcopy)
+
 
 def suite():
     suite = unittest.TestSuite()
@@ -423,6 +448,8 @@ def suite():
     suite.addTest(FramesTestFunctions('testRotation'))
     suite.addTest(FramesTestFunctions('testFrame'))
     suite.addTest(FramesTestFunctions('testPickle'))
+    suite.addTest(FramesTestFunctions('testCopy'))
+    suite.addTest(FramesTestFunctions('testDeepCopy'))
     return suite
 
 

--- a/python_orocos_kdl/tests/frameveltest.py
+++ b/python_orocos_kdl/tests/frameveltest.py
@@ -264,6 +264,28 @@ class FrameVelTestFunctions(unittest.TestCase):
 
         self.assertEqual(data, data1)
 
+    def testCopyImpl(self, copy):
+        vv1 = VectorVel(Vector(1, 2, 3), Vector(4, 5, 6))
+        vv2 = copy(vv1)
+        self.assertEqual(vv1, vv2)
+        rv1 = RotationVel(Rotation.RotX(1.3), Vector(4.1, 5.1, 6.1))
+        rv2 = copy(rv1)
+        self.assertEqual(rv1, rv2)
+        fv1 = FrameVel(rv1, vv1)
+        fv2 = copy(fv1)
+        self.assertEqual(fv1, fv2)
+        tv1 = TwistVel(vv1, vv1)
+        tv2 = copy(tv1)
+        self.assertEqual(tv1, tv2)
+
+    def testCopy(self):
+        from copy import copy
+        self.testCopyImpl(copy)
+
+    def testDeepCopy(self):
+        from copy import deepcopy
+        self.testCopyImpl(deepcopy)
+
 
 def suite():
     suite = unittest.TestSuite()
@@ -273,6 +295,8 @@ def suite():
     suite.addTest(FrameVelTestFunctions('testRotationVel'))
     suite.addTest(FrameVelTestFunctions('testFrameVel'))
     suite.addTest(FrameVelTestFunctions('testPickle'))
+    suite.addTest(FrameVelTestFunctions('testCopy'))
+    suite.addTest(FrameVelTestFunctions('testDeepCopy'))
     return suite
 
 


### PR DESCRIPTION
Added tests work fine for SIP based PyKDL, but fail on PyBind11 based PyKDL on Python2. I will submit an issue to PyBind11.