### PR TITLE
Declare assignment operator private for SIP

### DIFF
--- a/python_orocos_kdl/PyKDL/sip/dynamics.sip
+++ b/python_orocos_kdl/PyKDL/sip/dynamics.sip
@@ -93,4 +93,7 @@ public:
     int JntToCoriolis(const JntArray &q, const JntArray &q_dot, JntArray &coriolis);
     int JntToMass(const JntArray &q, JntSpaceInertiaMatrix& H);
     int JntToGravity(const JntArray &q,JntArray &gravity);
+
+private:
+    ChainDynParam& operator=(const ChainDynParam&);
 };

--- a/python_orocos_kdl/PyKDL/sip/kinfam.sip
+++ b/python_orocos_kdl/PyKDL/sip/kinfam.sip
@@ -412,6 +412,9 @@ public:
 //    Argument by reference doesn't work for container types
 //    virtual int JntToCart(const JntArray& q_in, std::vector<Frame>& p_out, int segmentNr=-1);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainFkSolverPos_recursive& operator=(const ChainFkSolverPos_recursive&);
 };
 
 class ChainFkSolverVel_recursive : ChainFkSolverVel
@@ -426,6 +429,9 @@ public:
 //    Argument by reference doesn't work for container types
 //    virtual int JntToCart(const JntArrayVel& q_in, std::vector<FrameVel>& out, int segmentNr=-1 );
     virtual void updateInternalDataStructures();
+
+private:
+    ChainFkSolverVel_recursive& operator=(const ChainFkSolverVel_recursive&);
 };
 
 class ChainIkSolverPos : SolverI {
@@ -461,6 +467,9 @@ public:
 
     virtual int CartToJnt(const JntArray& q_init , const Frame& p_in ,JntArray& q_out);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainIkSolverPos_NR& operator=(const ChainIkSolverPos_NR&);
 };
 
 class ChainIkSolverPos_NR_JL : ChainIkSolverPos
@@ -476,6 +485,9 @@ public:
 
     virtual int CartToJnt(const JntArray& q_init , const Frame& p_in ,JntArray& q_out);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainIkSolverPos_NR_JL& operator=(const ChainIkSolverPos_NR_JL&);
 };
 
 class ChainIkSolverVel_pinv : ChainIkSolverVel
@@ -489,6 +501,9 @@ public:
 
     virtual int CartToJnt(const JntArray& q_in, const Twist& v_in, JntArray& qdot_out);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainIkSolverVel_pinv& operator=(const ChainIkSolverVel_pinv&);
 };
 
 class ChainIkSolverVel_wdls : ChainIkSolverVel
@@ -598,6 +613,8 @@ public:
 
     void setLambda(const double& lambda);
 
+private:
+    ChainIkSolverVel_wdls& operator=(const ChainIkSolverVel_wdls&);
 };
 
 
@@ -612,6 +629,9 @@ public:
 
     virtual int CartToJnt(const JntArray& q_init , const Frame& p_in ,JntArray& q_out);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainIkSolverPos_LMA& operator=(const ChainIkSolverPos_LMA&);
 };
 
 
@@ -638,6 +658,9 @@ public:
     const JntArray& getOptPos()const /Factory/;
 
     const double& getAlpha()const /Factory/;
+
+private:
+    ChainIkSolverVel_pinv_nso& operator=(const ChainIkSolverVel_pinv_nso&);
 };
 
 class ChainIkSolverVel_pinv_givens : ChainIkSolverVel
@@ -651,6 +674,9 @@ public:
 
     virtual int CartToJnt(const JntArray& q_in, const Twist& v_in, JntArray& qdot_out);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainIkSolverVel_pinv_givens& operator=(const ChainIkSolverVel_pinv_givens&);
 };
 
 class ChainJntToJacSolver : SolverI
@@ -663,6 +689,9 @@ public:
     ChainJntToJacSolver(const Chain& chain);
     int JntToJac(const JntArray& q_in,Jacobian& jac, int seg_nr=-1);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainJntToJacSolver& operator=(const ChainJntToJacSolver&);
 };
 
 class ChainJntToJacDotSolver : SolverI
@@ -690,6 +719,9 @@ public:
     void setBodyFixedRepresentation();
     void setInertialRepresentation();
     void setRepresentation(const int& representation);
+
+private:
+    ChainJntToJacDotSolver& operator=(const ChainJntToJacDotSolver&);
 };
 
 class ChainIdSolver : SolverI
@@ -712,4 +744,7 @@ public:
     ChainIdSolver_RNE(const Chain& chain,Vector grav);
     int CartToJnt(const JntArray &q, const JntArray &q_dot, const JntArray &q_dotdot, const std::vector<Wrench>& f_ext,JntArray &torques);
     virtual void updateInternalDataStructures();
+
+private:
+    ChainIdSolver_RNE& operator=(const KDL::ChainIdSolver_RNE&);
 };


### PR DESCRIPTION
Starting with v4.19.23 SIP expects a working operator= or one marked
private explicitly. All classes in this PR have a reference member
(&chain) resulting in the compiler deleting the default assignment
operator. This PR makes this known to SIP as well.

Fixes #260 