### PR TITLE
Non-standard M_PI -> orocos' own PI for Mingw

### DIFF
--- a/orocos_kdl/src/frames.cpp
+++ b/orocos_kdl/src/frames.cpp
@@ -251,7 +251,7 @@ void Rotation::GetRPY(double& roll,double& pitch,double& yaw) const
     {
 		double epsilon=1E-12;
 		pitch = atan2(-data[6], sqrt( sqr(data[0]) +sqr(data[3]) )  );
-        if ( fabs(pitch) > (M_PI/2.0-epsilon) ) {
+        if ( fabs(pitch) > (PI/2.0-epsilon) ) {
             yaw = atan2(	-data[1], data[4]);
             roll  = 0.0 ;
         } else {
@@ -384,7 +384,7 @@ double Rotation::GetRotAngle(Vector& axis,double eps) const {
         }
 
         // otherwise this singularity is angle = 180
-        angle = M_PI;
+        angle = PI;
         double xx = (data[0] + 1) / 2;
         double yy = (data[4] + 1) / 2;
         double zz = (data[8] + 1) / 2;


### PR DESCRIPTION
While M_PI is absurdly common, it's not officially defined in the C++ standard. That may be why orocos uses PI in most places?

These uses of M_PI cause build errors on Mingw with clang, so this changes them to PI.