### PR TITLE
Add Industrial CI for ABI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ jobs:
       if: branch = release-1.3
     - <<: *industrial-ci
       name: Industrial CI Melodic
-      env: ROS_DISTRO="melodic" ROS_REPO=ros ABICHECK_URL='github:orocos/orocos_kinematics_dynamics#v1.4.0' ABICHECK_MERGE=auto
+      env: ROS_DISTRO="melodic" ROS_REPO=ros ABICHECK_URL='github:orocos/orocos_kinematics_dynamics#release-1.4' ABICHECK_MERGE=auto
       if: branch = release-1.4
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ jobs:
       services: docker
       install: git clone https://github.com/ros-industrial/industrial_ci.git -b master .ci_config
       script: source .ci_config/travis.sh
+      if: branch = release-1.3
     - <<: *industrial-ci
       name: Industrial CI Melodic
       env: ROS_DISTRO="melodic" ROS_REPO=ros ABICHECK_URL='github:orocos/orocos_kinematics_dynamics#v1.4.0' ABICHECK_MERGE=auto
-  allow_failures:
-    - stage: Industrial CI
+      if: branch = release-1.4
 
 install:
   - sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ jobs:
       env: ROS_DISTRO="melodic" ROS_REPO=ros ABICHECK_URL='github:orocos/orocos_kinematics_dynamics#v1.4.0' ABICHECK_MERGE=auto
 
 
-before_script:
+install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libeigen3-dev libcppunit-dev python-psutil python3-psutil python-future python3-future
   # build orocos_kdl

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,41 @@ language: cpp
 os: linux
 dist: xenial
 
-compiler:
-  - gcc
-  - clang
-
 env:
   global:
     - CXXFLAGS="-Wall -Wextra -Wno-unused-parameter"
-  jobs:
-    - OROCOS_KDL_BUILD_TYPE=Debug
-    - OROCOS_KDL_BUILD_TYPE=Release
 
 jobs:
   include:
-    - env: OROCOS_KDL_BUILD_TYPE=Debug
+    - &cmake
+      stage: CMake
+      name: GCC Debug
+      env: OROCOS_KDL_BUILD_TYPE=Debug
       compiler: gcc
-    - env: OROCOS_KDL_BUILD_TYPE=Release
+    - <<: *cmake
+      name: GCC Release
+      env: OROCOS_KDL_BUILD_TYPE=Release
       compiler: gcc
-    - env: OROCOS_KDL_BUILD_TYPE=Debug
+    - <<: *cmake
+      name: CLang Debug
+      env: OROCOS_KDL_BUILD_TYPE=Debug
       compiler: clang
-    - env: OROCOS_KDL_BUILD_TYPE=Release
+    - <<: *cmake
+      name: CLang Release
+      env: OROCOS_KDL_BUILD_TYPE=Release
       compiler: clang
+    - &industrial-ci
+      stage: Industrial CI
+      name: Industrial CI Kinetic
+      env: ROS_DISTRO="kinetic" ROS_REPO=ros ABICHECK_URL='github:orocos/orocos_kinematics_dynamics#release-1.3'
+      compiler: gcc
+      services: docker
+      install: git clone https://github.com/ros-industrial/industrial_ci.git -b master .ci_config
+      script: source .ci_config/travis.sh
+    - <<: *industrial-ci
+      name: Industrial CI Melodic
+      env: ROS_DISTRO="melodic" ROS_REPO=ros ABICHECK_URL='github:orocos/orocos_kinematics_dynamics#v1.4.0' ABICHECK_MERGE=auto
+
 
 before_script:
   - sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ jobs:
     - <<: *industrial-ci
       name: Industrial CI Melodic
       env: ROS_DISTRO="melodic" ROS_REPO=ros ABICHECK_URL='github:orocos/orocos_kinematics_dynamics#v1.4.0' ABICHECK_MERGE=auto
-
+  allow_failures:
+    - stage: Industrial CI
 
 install:
   - sudo apt-get -qq update

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,17 @@ env:
     - OROCOS_KDL_BUILD_TYPE=Debug
     - OROCOS_KDL_BUILD_TYPE=Release
 
+jobs:
+  include:
+    - env: OROCOS_KDL_BUILD_TYPE=Debug
+      compiler: gcc
+    - env: OROCOS_KDL_BUILD_TYPE=Release
+      compiler: gcc
+    - env: OROCOS_KDL_BUILD_TYPE=Debug
+      compiler: clang
+    - env: OROCOS_KDL_BUILD_TYPE=Release
+      compiler: clang
+
 before_script:
   - sudo apt-get -qq update
   - sudo apt-get install -y libeigen3-dev libcppunit-dev python-psutil python3-psutil python-future python3-future


### PR DESCRIPTION
I have added Industrial CI for its ABI check.

It is only executed if the target branch is `release-1.3/1.4`, depending on the ROS distro. This way we have a valid check to determine if we can update a release.

To see the industrial CI does work and the ABI check fails, see https://travis-ci.com/github/orocos/orocos_kinematics_dynamics/builds/201521209

I have created a `release-1.4` branch at the `v1.4.0` tag. @meyerj @smits could one of you enable branch protection on it?