### PR TITLE
External wrench estimator: first-order momentum observer

### DIFF
--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -164,7 +164,8 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
 
     // Compute robot's jacobian for the end-effector frame, expressed in the base frame
     solver_result = jacobian_solver.JntToJac(joint_position, jacobian_end_eff);
-    if (solver_result != 0) return solver_result;
+    if (solver_result != 0)
+        return solver_result;
 
     // Transform the jacobian from the base frame to the end-effector frame. 
     // This part can be commented out if the user wants its estimated wrench to be expressed w.r.t. base frame 

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -174,7 +174,8 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
     // SVD of "Jac^T" with maximum iterations "maxiter": Jac^T = U * S^-1 * V^T
     jacobian_end_eff_t = jacobian_end_eff.data.transpose();
     solver_result = svd_eigen_HH(jacobian_end_eff_t, U, S, V, tmp, svd_maxiter);
-    if (solver_result != 0) return (error = E_SVD_FAILED);
+    if (solver_result != 0)
+        return (error = E_SVD_FAILED);
 
     // Invert singular values: S^-1
     for (int i = 0; i < S.size(); ++i)

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -111,8 +111,10 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
      */
 
     // Check sizes first
-    if (nj != CHAIN.getNrOfJoints() || ns != CHAIN.getNrOfSegments()) return (error = E_NOT_UP_TO_DATE);
-    if (joint_position.rows() != nj || joint_velocity.rows() != nj || joint_torque.rows() != nj) return (error = E_SIZE_MISMATCH);
+    if (nj != CHAIN.getNrOfJoints() || ns != CHAIN.getNrOfSegments())
+        return (error = E_NOT_UP_TO_DATE);
+    if (joint_position.rows() != nj || joint_velocity.rows() != nj || joint_torque.rows() != nj)
+        return (error = E_SIZE_MISMATCH);
 
     /**
      * =======================================================================================================================

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -73,7 +73,8 @@ void ChainExternalWrenchEstimator::updateInternalDataStructures()
 int ChainExternalWrenchEstimator::setInitialMomentum(const JntArray &joint_position, const JntArray &joint_velocity)
 {
     // Check sizes first
-    if (joint_position.rows() != nj || joint_velocity.rows() != nj) return (error = E_SIZE_MISMATCH);
+    if (joint_position.rows() != nj || joint_velocity.rows() != nj)
+        return (error = E_SIZE_MISMATCH);
 
     // Calculate robot's inertia and momentum in the joint space
     dynparam_solver.JntToMass(joint_position, jnt_mass_matrix);

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -1,0 +1,162 @@
+// Copyright  (C)  2021 Djordje Vukcevic <djordje dot vukcevic at h-brs dot de>
+
+// Version: 1.0
+// Author: Djordje Vukcevic <djordje dot vukcevic at h-brs dot de>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#include "chainexternalwrenchestimator.hpp"
+namespace KDL {
+
+ChainExternalWrenchEstimator::ChainExternalWrenchEstimator(const Chain &chain, const Vector &gravity, const double sample_frequency, const double estimation_gain, const double filter_constant) :
+    CHAIN(chain),
+    DT_SEC(1.0 / sample_frequency), FILTER_CONST(filter_constant),
+    nj(CHAIN.getNrOfJoints()), ns(CHAIN.getNrOfSegments()),
+    jnt_mass_matrix(nj), previous_jnt_mass_matrix(nj),
+    initial_jnt_momentum(nj), estimated_momentum_integral(nj), filtered_estimated_ext_torque(nj),
+    ESTIMATION_GAIN(Eigen::VectorXd::Constant(nj, estimation_gain)),
+    dynparam_solver(CHAIN, gravity),
+    jacobian_solver(CHAIN),
+    fk_pos_solver(CHAIN)
+{
+}
+
+void ChainExternalWrenchEstimator::updateInternalDataStructures()
+{
+    nj = CHAIN.getNrOfJoints();
+    ns = CHAIN.getNrOfSegments();
+    jnt_mass_matrix.resize(nj);
+    previous_jnt_mass_matrix.resize(nj);
+    initial_jnt_momentum.resize(nj);
+    estimated_momentum_integral.resize(nj);
+    filtered_estimated_ext_torque.resize(nj);
+    ESTIMATION_GAIN.conservativeResizeLike(Eigen::VectorXd::Constant(nj, ESTIMATION_GAIN(0)));
+    dynparam_solver.updateInternalDataStructures();
+    jacobian_solver.updateInternalDataStructures();
+    fk_pos_solver.updateInternalDataStructures();
+}
+
+// Calculates robot's initial momentum in the joint space. If this method is not called by the user, zero values will be taken for the initial momentum.
+int ChainExternalWrenchEstimator::setInitialMomentum(const JntArray &joint_position, const JntArray &joint_velocity)
+{
+    // Check sizes first
+    if (joint_position.rows() != nj || joint_velocity.rows() != nj) return (error = E_SIZE_MISMATCH);
+
+    // Calculate robot's inertia and momentum in the joint space
+    dynparam_solver.JntToMass(joint_position, jnt_mass_matrix);
+    initial_jnt_momentum.data = jnt_mass_matrix.data * joint_velocity.data;
+
+    // Reset data because of the new momentum offset
+    SetToZero(estimated_momentum_integral);
+    SetToZero(filtered_estimated_ext_torque);
+
+    return (error = E_NOERROR);
+}
+
+// This method calculates the external wrench that is applied on the robot's end-effector.
+int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position, const JntArray &joint_velocity, const JntArray &joint_torque, Wrench &external_wrench)
+{
+    /**
+     * ==========================================================================
+     * First-order momentum observer, an implementation based on:
+     * S. Haddadin, A. De Luca and A. Albu-Schäffer,
+     * "Robot Collisions: A Survey on Detection, Isolation, and Identification,"
+     * in IEEE Transactions on Robotics, vol. 33(6), pp. 1292-1312, 2017.
+     * ==========================================================================
+     */
+
+    // Check sizes first
+    if (nj != CHAIN.getNrOfJoints() || ns != CHAIN.getNrOfSegments()) return (error = E_NOT_UP_TO_DATE);
+    if (joint_position.rows() != nj || joint_velocity.rows() != nj || joint_torque.rows() != nj) return (error = E_SIZE_MISMATCH);
+
+    /**
+     * =======================================================================================================================
+     * Part I: Estimation of the torques that are felt in joints as a result of the external wrench being applied on the robot
+     * =======================================================================================================================
+     */
+
+    // Calculate decomposed robot's dynamics
+    JntArray gravity_torque(nj), coriolis_torque(nj);
+    int solver_result = dynparam_solver.JntToMass(joint_position, jnt_mass_matrix);
+    if (solver_result != 0) return solver_result;
+    solver_result = dynparam_solver.JntToCoriolis(joint_position, joint_velocity, coriolis_torque);
+    if (solver_result != 0) return solver_result;
+    solver_result = dynparam_solver.JntToGravity(joint_position, gravity_torque);
+    if (solver_result != 0) return solver_result;
+
+    // Calculate the change of robot's inertia in the joint space
+    JntSpaceInertiaMatrix jnt_mass_matrix_dot(nj);
+    jnt_mass_matrix_dot.data = (jnt_mass_matrix.data - previous_jnt_mass_matrix.data) / DT_SEC;
+
+    // Save data for the next iteration
+    previous_jnt_mass_matrix.data = jnt_mass_matrix.data;
+
+    // Calculate total torque exerted on the joint
+    JntArray total_torque(nj);
+    total_torque.data = joint_torque.data - gravity_torque.data - coriolis_torque.data + jnt_mass_matrix_dot.data * joint_velocity.data;
+
+    // Accumulate main integral
+    estimated_momentum_integral.data += (total_torque.data + filtered_estimated_ext_torque.data) * DT_SEC;
+
+    // Estimate external joint torque
+    JntArray estimated_ext_torque(nj);
+    estimated_ext_torque.data = ESTIMATION_GAIN.asDiagonal() * (jnt_mass_matrix.data * joint_velocity.data - estimated_momentum_integral.data - initial_jnt_momentum.data);
+
+    // First order low-pass filter: filter out the noise from the estimated signal
+    // This filter can be turned off by setting FILTER_CONST value to 0
+    filtered_estimated_ext_torque.data = FILTER_CONST * filtered_estimated_ext_torque.data + (1.0 - FILTER_CONST) * estimated_ext_torque.data;
+
+    /**
+     * ==================================================================================================================
+     * Part II: Propagate above-estimated joint torques to Cartesian wrench using a pseudo-inverse of Jacobian-Transpose
+     * ==================================================================================================================
+     */
+    
+    // Compute robot's end-effector frame, expressed in the base frame
+    Frame end_eff_frame;
+    solver_result = fk_pos_solver.JntToCart(joint_position, end_eff_frame);
+    if (solver_result != 0) return solver_result;
+
+    // Compute robot's jacobian for the end-effector frame, expressed in the base frame
+    Jacobian jacobian_end_eff(nj);
+    solver_result = jacobian_solver.JntToJac(joint_position, jacobian_end_eff);
+    if (solver_result != 0) return solver_result;
+
+    // Transform the jacobian from the base frame to the end-effector frame. 
+    // This part can be commented out if the user wants its estimated wrench to be expressed w.r.t. base frame 
+    jacobian_end_eff.changeBase(end_eff_frame.M.Inverse()); // Jacobian is now expressed w.r.t. end-effector frame
+
+    // Compute SVD of the jacobian using Eigen functions
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(jacobian_end_eff.data.transpose(), Eigen::ComputeThinU | Eigen::ComputeThinV);
+
+    // Invert singular values
+    Eigen::VectorXd singular_inv(svd.singularValues());
+    for (int j = 0; j < singular_inv.size(); ++j)
+        singular_inv(j) = (singular_inv(j) < 1e-8) ? 0.0 : 1.0 / singular_inv(j);
+
+    // Compose SVD
+    Eigen::MatrixXd jacobian_end_eff_inv;
+    jacobian_end_eff_inv.noalias() = svd.matrixV() * singular_inv.matrix().asDiagonal() * svd.matrixU().adjoint();
+
+    // Compute end-effector's Cartesian wrench from the estimated joint torques
+    Eigen::VectorXd estimated_wrench = jacobian_end_eff_inv * filtered_estimated_ext_torque.data;
+    for (int i = 0; i < 6; i++) 
+        external_wrench(i) = estimated_wrench(i);
+
+    return (error = E_NOERROR);
+}
+
+} // namespace

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -121,9 +121,9 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
         return (error = E_SIZE_MISMATCH);
 
     /**
-     * =======================================================================================================================
-     * Part I: Estimation of the torques that are felt in joints as a result of the external wrench being applied on the robot
-     * =======================================================================================================================
+     * ================================================================================================================
+     * Part I: Estimation of the torques felt in joints as a result of the external wrench being applied on the robot
+     * ================================================================================================================
      */
 
     // Calculate decomposed robot's dynamics
@@ -171,7 +171,7 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
         return (error = E_JACSOLVER_FAILED);
 
     // Transform the jacobian from the base frame to the end-effector frame. 
-    // This part can be commented out if the user wants its estimated wrench to be expressed w.r.t. base frame 
+    // This part can be commented out if the user wants estimated wrench to be expressed w.r.t. base frame 
     jacobian_end_eff.changeBase(end_eff_frame.M.Inverse()); // Jacobian is now expressed w.r.t. end-effector frame
 
     // SVD of "Jac^T" with maximum iterations "maxiter": Jac^T = U * S^-1 * V^T

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -159,7 +159,8 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
     // Compute robot's end-effector frame, expressed in the base frame
     Frame end_eff_frame;
     solver_result = fk_pos_solver.JntToCart(joint_position, end_eff_frame);
-    if (solver_result != 0) return solver_result;
+    if (solver_result != 0)
+        return solver_result;
 
     // Compute robot's jacobian for the end-effector frame, expressed in the base frame
     solver_result = jacobian_solver.JntToJac(joint_position, jacobian_end_eff);

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -159,4 +159,11 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
     return (error = E_NOERROR);
 }
 
+// Getter for the torques felt in the robot's joints due to the external wrench being applied on the robot
+void ChainExternalWrenchEstimator::getEstimatedJntTorque(JntArray &external_joint_torque)
+{
+    assert(external_joint_torque.rows() == filtered_estimated_ext_torque.rows());
+    external_joint_torque = filtered_estimated_ext_torque;
+}
+
 } // namespace

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -19,6 +19,7 @@
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "chainexternalwrenchestimator.hpp"
+
 namespace KDL {
 
 ChainExternalWrenchEstimator::ChainExternalWrenchEstimator(const Chain &chain, const Vector &gravity, const double sample_frequency, const double estimation_gain, const double filter_constant, const double eps, const int maxiter) :

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -80,6 +80,18 @@ int ChainExternalWrenchEstimator::setInitialMomentum(const JntArray &joint_posit
     return (error = E_NOERROR);
 }
 
+// Sets singular-value eps parameter for the SVD calculation
+void ChainExternalWrenchEstimator::setSVDEps(const double eps_in)
+{
+    svd_eps = eps_in;
+}
+
+// Sets maximum iteration parameter for the SVD calculation
+void ChainExternalWrenchEstimator::setSVDMaxIter(const int maxiter_in)
+{
+    svd_maxiter = maxiter_in;
+}
+
 // This method calculates the external wrench that is applied on the robot's end-effector.
 int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position, const JntArray &joint_velocity, const JntArray &joint_torque, Wrench &external_wrench)
 {

--- a/orocos_kdl/src/chainexternalwrenchestimator.cpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.cpp
@@ -122,11 +122,14 @@ int ChainExternalWrenchEstimator::JntToExtWrench(const JntArray &joint_position,
 
     // Calculate decomposed robot's dynamics
     int solver_result = dynparam_solver.JntToMass(joint_position, jnt_mass_matrix);
-    if (solver_result != 0) return solver_result;
+    if (solver_result != 0)
+        return solver_result;
     solver_result = dynparam_solver.JntToCoriolis(joint_position, joint_velocity, coriolis_torque);
-    if (solver_result != 0) return solver_result;
+    if (solver_result != 0)
+        return solver_result;
     solver_result = dynparam_solver.JntToGravity(joint_position, gravity_torque);
-    if (solver_result != 0) return solver_result;
+    if (solver_result != 0)
+        return solver_result;
 
     // Calculate the change of robot's inertia in the joint space
     jnt_mass_matrix_dot.data = (jnt_mass_matrix.data - previous_jnt_mass_matrix.data) / DT_SEC;

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -18,8 +18,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-#ifndef KDL_EXTERNAL_WRENCH_ESTIMATOR_HPP
-#define KDL_EXTERNAL_WRENCH_ESTIMATOR_HPP
+#ifndef KDL_CHAIN_EXTERNAL_WRENCH_ESTIMATOR_HPP
+#define KDL_CHAIN_EXTERNAL_WRENCH_ESTIMATOR_HPP
 
 #include <Eigen/Core>
 #include "utilities/svd_eigen_HH.hpp"

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -1,0 +1,97 @@
+// Copyright  (C)  2021 Djordje Vukcevic <djordje dot vukcevic at h-brs dot de>
+
+// Version: 1.0
+// Author: Djordje Vukcevic <djordje dot vukcevic at h-brs dot de>
+// URL: http://www.orocos.org/kdl
+
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// Lesser General Public License for more details.
+
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+#ifndef KDL_EXTERNAL_WRENCH_ESTIMATOR_HPP
+#define KDL_EXTERNAL_WRENCH_ESTIMATOR_HPP
+
+#include <Eigen/Core>
+#include <Eigen/SVD> 
+#include "chaindynparam.hpp"
+#include "chainjnttojacsolver.hpp"
+#include "chainfksolverpos_recursive.hpp"
+#include <iostream>
+
+namespace KDL {
+
+    /**
+     * \brief First-order momentum observer for the estimation of external wrenches applied on the robot's end-effector. 
+     *
+     * Implementation based on:
+     * S. Haddadin, A. De Luca and A. Albu-Schäffer,
+     * "Robot Collisions: A Survey on Detection, Isolation, and Identification,"
+     * in IEEE Transactions on Robotics, vol. 33(6), pp. 1292-1312, 2017.
+     */
+    class ChainExternalWrenchEstimator : public SolverI
+    {
+    public:
+        /**
+         * Constructor for the estimator, it will allocate all the necessary memory
+         * \param chain The kinematic chain of the robot, an internal copy will be made.
+         * \param gravity The gravity-acceleration vector to use during the calculation.
+         * \param sample_frequency Frequency at which users updates it estimation loop (in Hz).
+         * \param filter_constant Parameter defining how much the estimated signal should be filtered by the low-pass filter.
+         *                        This input value should be between 0 and 1. Higher the number means more noise needs to be filtered-out.
+         *                        The filter can be turned off by setting this value to 0.
+         */
+        ChainExternalWrenchEstimator(const Chain &chain, const Vector &gravity, const double sample_frequency, const double estimation_gain, const double filter_constant);
+        ~ChainExternalWrenchEstimator(){};
+
+        /**
+         * Calculates robot's initial momentum in the joint space. 
+         * Bassically, sets the offset for future estimation (momentum calculation).
+         * If this method is not called by the user, zero values will be taken for the initial momentum.
+         */
+        int setInitialMomentum(const JntArray &joint_position, const JntArray &joint_velocity);
+
+        /**
+         * This method calculates the external wrench that is applied on the robot's end-effector.
+         * Input parameters:
+         * \param joint_position The current (measured) joint positions.
+         * \param joint_velocity The current (measured) joint velocities.
+         * \param joint_torque The joint space torques. 
+         *                     Depending on the user's choice, this array can represent commanded or measured joint torques.
+         *                     A particular choice depends on the available sensors in robot's joint. 
+         *                     For more details see the above-referenced article.
+         *
+         * Output parameters:
+         * \param external_wrench The estimated external wrench applied on the robot's end-effector.
+         *                        The wrench will be expressed w.r.t. end-effector's frame.
+         *
+         * @return error/success code
+         */
+        int JntToExtWrench(const JntArray &joint_position, const JntArray &joint_velocity, const JntArray &joint_torque, Wrench &external_wrench);
+
+        /// @copydoc KDL::SolverI::updateInternalDataStructures()
+        virtual void updateInternalDataStructures();
+
+    private:
+        const Chain &CHAIN;
+        const double DT_SEC, FILTER_CONST;
+        unsigned int nj, ns;
+        JntSpaceInertiaMatrix jnt_mass_matrix, previous_jnt_mass_matrix;
+        JntArray initial_jnt_momentum, estimated_momentum_integral, filtered_estimated_ext_torque;
+        Eigen::VectorXd ESTIMATION_GAIN;
+        ChainDynParam dynparam_solver;
+        ChainJntToJacSolver jacobian_solver;
+        ChainFkSolverPos_recursive fk_pos_solver;
+    };
+}
+
+#endif

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -37,6 +37,8 @@ namespace KDL {
      * S. Haddadin, A. De Luca and A. Albu-Schäffer,
      * "Robot Collisions: A Survey on Detection, Isolation, and Identification,"
      * in IEEE Transactions on Robotics, vol. 33(6), pp. 1292-1312, 2017.
+     * 
+     * Note: This component assumes that the external wrench is applied on the end-effector (last) link of the robot's chain.
      */
     class ChainExternalWrenchEstimator : public SolverI
     {

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -45,6 +45,13 @@ namespace KDL {
         typedef Eigen::Matrix<double, 6, 1 > Vector6d;
 
     public:
+
+        static const int E_FKSOLVERPOS_FAILED = -100; //! Internally-used Forward Position Kinematics (Recursive) solver failed
+        static const int E_JACSOLVER_FAILED = -101; //! Internally-used Jacobian solver failed
+        static const int E_DYNPARAMSOLVERMASS_FAILED = -102; //! Internally-used Dynamics Parameters (Mass) solver failed
+        static const int E_DYNPARAMSOLVERCORIOLIS_FAILED = -103; //! Internally-used Dynamics Parameters (Coriolis) solver failed
+        static const int E_DYNPARAMSOLVERGRAVITY_FAILED = -104; //! Internally-used Dynamics Parameters (Gravity) solver failed
+
         /**
          * Constructor for the estimator, it will allocate all the necessary memory
          * \param chain The kinematic chain of the robot, an internal copy will be made.
@@ -95,6 +102,9 @@ namespace KDL {
 
         /// @copydoc KDL::SolverI::updateInternalDataStructures()
         virtual void updateInternalDataStructures();
+
+        /// @copydoc KDL::SolverI::strError()
+        virtual const char* strError(const int error) const;
 
     private:
         const Chain &CHAIN;

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -78,6 +78,9 @@ namespace KDL {
          */
         int JntToExtWrench(const JntArray &joint_position, const JntArray &joint_velocity, const JntArray &joint_torque, Wrench &external_wrench);
 
+        // Returns the torques felt in the robot's joints as a result of the external wrench being applied on the robot.
+        void getEstimatedJntTorque(JntArray &external_joint_torque);
+
         /// @copydoc KDL::SolverI::updateInternalDataStructures()
         virtual void updateInternalDataStructures();
 

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -57,6 +57,7 @@ namespace KDL {
          * \param chain The kinematic chain of the robot, an internal copy will be made.
          * \param gravity The gravity-acceleration vector to use during the calculation.
          * \param sample_frequency Frequency at which users updates it estimation loop (in Hz).
+         * \param estimation_gain Parameter used to control the estimator's convergence
          * \param filter_constant Parameter defining how much the estimated signal should be filtered by the low-pass filter.
          *                        This input value should be between 0 and 1. Higher the number means more noise needs to be filtered-out.
          *                        The filter can be turned off by setting this value to 0.

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -64,6 +64,12 @@ namespace KDL {
          */
         int setInitialMomentum(const JntArray &joint_position, const JntArray &joint_velocity);
 
+        // Sets singular-value eps parameter for the SVD calculation
+        void setSVDEps(const double eps_in);
+
+        // Sets maximum iteration parameter for the SVD calculation
+        void setSVDMaxIter(const int maxiter_in);
+
         /**
          * This method calculates the external wrench that is applied on the robot's end-effector.
          * Input parameters:

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -100,7 +100,7 @@ namespace KDL {
         double svd_eps;
         int svd_maxiter;
         unsigned int nj, ns;
-        JntSpaceInertiaMatrix jnt_mass_matrix, previous_jnt_mass_matrix;
+        JntSpaceInertiaMatrix jnt_mass_matrix, previous_jnt_mass_matrix, jnt_mass_matrix_dot;
         JntArray initial_jnt_momentum, estimated_momentum_integral, filtered_estimated_ext_torque, 
                  gravity_torque, coriolis_torque, total_torque, estimated_ext_torque;
         Jacobian jacobian_end_eff;

--- a/orocos_kdl/src/chainexternalwrenchestimator.hpp
+++ b/orocos_kdl/src/chainexternalwrenchestimator.hpp
@@ -106,7 +106,7 @@ namespace KDL {
         JntArray initial_jnt_momentum, estimated_momentum_integral, filtered_estimated_ext_torque, 
                  gravity_torque, coriolis_torque, total_torque, estimated_ext_torque;
         Jacobian jacobian_end_eff;
-        Eigen::MatrixXd jacobian_end_eff_t, jacobian_end_eff_t_inv, U, V;
+        Eigen::MatrixXd jacobian_end_eff_transpose, jacobian_end_eff_transpose_inv, U, V;
         Eigen::VectorXd S, S_inv, tmp, ESTIMATION_GAIN;
         ChainDynParam dynparam_solver;
         ChainJntToJacSolver jacobian_solver;

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -1637,12 +1637,10 @@ void SolverTest::ExternalWrenchEstimatorTest()
     ext_torque_reference.data = jacobian_end_eff.data.transpose() * wrench;
 
     // Arm root acceleration (robot's base mounted on an even surface)
-    // Note: Vereshchagin solver takes root acc. with opposite sign comparead to the above FD and RNE solvers
-    Vector linearAcc(0.0, 0.0, 9.81); Vector angularAcc(0.0, 0.0, 0.0);
-    Twist root_Acc(linearAcc, angularAcc);
+    Vector linearAcc(0.0, 0.0, -9.81); Vector angularAcc(0.0, 0.0, 0.0);
 
     // RNE ID solver for control purposes
-    KDL::ChainIdSolver_RNE IdSolver(kukaLWR, -linearAcc);
+    KDL::ChainIdSolver_RNE IdSolver(kukaLWR, linearAcc);
 
     // Vereshchagin Hybrid Dynamics solver for simulation purposes
     int numberOfConstraints = 6;
@@ -1650,7 +1648,8 @@ void SolverTest::ExternalWrenchEstimatorTest()
     JntArray beta(numberOfConstraints); // Acceleration energy at the end-effector
     KDL::SetToZero(alpha); // Set to zero to deactivate all constraints
     KDL::SetToZero(beta); // Set to zero to deactivate all constraints
-    ChainHdSolver_Vereshchagin constraintSolver(kukaLWR, root_Acc, numberOfConstraints);
+    Twist vereshchagin_root_Acc(-linearAcc, angularAcc); // Note: Vereshchagin solver takes root acc. with opposite sign comparead to the above FD and RNE solvers
+    ChainHdSolver_Vereshchagin constraintSolver(kukaLWR, vereshchagin_root_Acc, numberOfConstraints);
 
     // External Wrench Estimator
     double sample_frequency = 10000.0; // Hz

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -247,6 +247,7 @@ void SolverTest::UpdateChainTest()
     ChainIdSolver_RNE idsolver1(chain2, Vector::Zero());
     unsigned int nr_of_constraints = 4;
     ChainHdSolver_Vereshchagin hdsolver(chain2,Twist::Zero(),4);
+    ChainExternalWrenchEstimator extwrench_estimator(chain2,Vector::Zero(), 100.0, 30.0, 0.5);
 
     JntArray q_in(chain2.getNrOfJoints());
     JntArray q_in2(chain2.getNrOfJoints());
@@ -266,6 +267,7 @@ void SolverTest::UpdateChainTest()
     FrameVel T2;
     Wrenches wrenches(chain2.getNrOfSegments());
     JntSpaceInertiaMatrix m(chain2.getNrOfJoints());
+    Wrench wrench_out;
 
     Jacobian alpha(nr_of_constraints - 1);
     JntArray beta(nr_of_constraints - 1);
@@ -291,6 +293,7 @@ void SolverTest::UpdateChainTest()
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_NOT_UP_TO_DATE, dynparam.JntToCoriolis(q_in, q_in2, q_out));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_NOT_UP_TO_DATE, dynparam.JntToGravity(q_in, q_out));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_NOT_UP_TO_DATE, dynparam.JntToMass(q_in, m));
+    CPPUNIT_ASSERT_EQUAL((int)SolverI::E_NOT_UP_TO_DATE, extwrench_estimator.JntToExtWrench(q_in,q_in2,ff_tau,wrench_out));
 
     jacsolver1.updateInternalDataStructures();
     jacdotsolver1.updateInternalDataStructures();
@@ -304,6 +307,7 @@ void SolverTest::UpdateChainTest()
     idsolver1.updateInternalDataStructures();
     hdsolver.updateInternalDataStructures();
     dynparam.updateInternalDataStructures();
+    extwrench_estimator.updateInternalDataStructures();
 
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH,fksolverpos.JntToCart(q_in, T, chain2.getNrOfSegments()));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH,fksolvervel.JntToCart(q_in3, T2, chain2.getNrOfSegments()));
@@ -322,6 +326,7 @@ void SolverTest::UpdateChainTest()
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, dynparam.JntToCoriolis(q_in, q_in2, q_out));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, dynparam.JntToGravity(q_in, q_out));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, dynparam.JntToMass(q_in, m));
+    CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, extwrench_estimator.JntToExtWrench(q_in,q_in2,ff_tau,wrench_out));
 
     q_in.resize(chain2.getNrOfJoints());
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, jacsolver1.JntToJac(q_in, jac, chain2.getNrOfSegments()));
@@ -339,10 +344,12 @@ void SolverTest::UpdateChainTest()
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, dynparam.JntToCoriolis(q_in, q_in2, q_out));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, dynparam.JntToGravity(q_in, q_out));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, dynparam.JntToMass(q_in, m));
+    CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, extwrench_estimator.JntToExtWrench(q_in,q_in2,ff_tau,wrench_out));
     q_in2.resize(chain2.getNrOfJoints());
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, dynparam.JntToCoriolis(q_in, q_in2, q_out));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, idsolver1.CartToJnt(q_in,q_in2,q_out,wrenches,q_out2));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, hdsolver.CartToJnt(q_in,q_in2,q_out,alpha,beta,wrenches, ff_tau, constraint_tau));
+    CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, extwrench_estimator.JntToExtWrench(q_in,q_in2,ff_tau,wrench_out));
     wrenches.resize(chain2.getNrOfSegments());
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, idsolver1.CartToJnt(q_in,q_in2,q_out,wrenches,q_out2));
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_SIZE_MISMATCH, hdsolver.CartToJnt(q_in,q_in2,q_out,alpha,beta,wrenches, ff_tau, constraint_tau));
@@ -379,6 +386,7 @@ void SolverTest::UpdateChainTest()
     CPPUNIT_ASSERT((int)SolverI::E_NOERROR <= dynparam.JntToCoriolis(q_in, q_in2, q_out));
     CPPUNIT_ASSERT((int)SolverI::E_NOERROR <= dynparam.JntToGravity(q_in, q_out));
     CPPUNIT_ASSERT((int)SolverI::E_NOERROR <= dynparam.JntToMass(q_in, m));
+    CPPUNIT_ASSERT((int)SolverI::E_NOERROR <= extwrench_estimator.JntToExtWrench(q_in,q_in2,ff_tau,wrench_out));
 }
 void SolverTest::FkPosAndJacTest()
 {

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -1708,29 +1708,17 @@ void SolverTest::ExternalWrenchEstimatorTest()
         
         // Estimate external wrench
         extwrench_estimator.JntToExtWrench(q, qd, command_torque, f_tool_estimated);
-        extwrench_estimator.getEstimatedJntTorque(ext_torque_estimated);
     }
 
     // ##################################################################################
     // Final comparison
     // ##################################################################################
-    
-    // Estimated Wrench
     CPPUNIT_ASSERT(Equal(f_tool_estimated(0), f_tool_reference(0), eps));
     CPPUNIT_ASSERT(Equal(f_tool_estimated(1), f_tool_reference(1), eps));
     CPPUNIT_ASSERT(Equal(f_tool_estimated(2), f_tool_reference(2), eps));
     CPPUNIT_ASSERT(Equal(f_tool_estimated(3), f_tool_reference(3), eps));
     CPPUNIT_ASSERT(Equal(f_tool_estimated(4), f_tool_reference(4), eps));
     CPPUNIT_ASSERT(Equal(f_tool_estimated(5), f_tool_reference(5), eps));
-
-    // Estimated Joint torques
-    CPPUNIT_ASSERT(Equal(ext_torque_estimated(0), ext_torque_reference(0), eps));
-    CPPUNIT_ASSERT(Equal(ext_torque_estimated(1), ext_torque_reference(1), eps));
-    CPPUNIT_ASSERT(Equal(ext_torque_estimated(2), ext_torque_reference(2), eps));
-    CPPUNIT_ASSERT(Equal(ext_torque_estimated(3), ext_torque_reference(3), eps));
-    CPPUNIT_ASSERT(Equal(ext_torque_estimated(4), ext_torque_reference(4), eps));
-    CPPUNIT_ASSERT(Equal(ext_torque_estimated(5), ext_torque_reference(5), eps));
-    CPPUNIT_ASSERT(Equal(ext_torque_estimated(6), ext_torque_reference(6), eps));
 
     return;
 }

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -1571,7 +1571,7 @@ void SolverTest::ExternalWrenchEstimatorTest()
     std::cout << "KDL External Wrench Estimator Test" << std::endl;
 
     int ret;
-    double eps = 0.85;
+    double eps = 0.7;
     unsigned int nj = kukaLWR.getNrOfJoints();
     unsigned int ns = kukaLWR.getNrOfSegments();
     CPPUNIT_ASSERT(Equal(nj, ns)); // Current implementation of the Vereshchagin solver can only work with chains that have equal number of joints and segments
@@ -1655,7 +1655,7 @@ void SolverTest::ExternalWrenchEstimatorTest()
     double sample_frequency = 10000.0; // Hz
     double estimation_gain  = 30.0;
     double filter_constant  = 0.5;
-    ChainExternalWrenchEstimator extwrench_estimator(kukaLWR, -linearAcc, sample_frequency, estimation_gain, filter_constant);
+    ChainExternalWrenchEstimator extwrench_estimator(kukaLWR, linearAcc, sample_frequency, estimation_gain, filter_constant);
     extwrench_estimator.setInitialMomentum(q, qd); // sets the offset for future estimation (momentum calculation)
 
     // ##########################################################################################

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -1704,7 +1704,7 @@ void SolverTest::ExternalWrenchEstimatorTest()
         
         // State integration: integrate from model accelerations to next joint state (positions and velocities)
         qd.data = qd.data + qdd.data * timeDelta; // Euler Forward
-        q.data = q.data + (qd.data - qdd.data * timeDelta / 2.0) * timeDelta; //Trapezoidal rule
+        q.data = q.data + qd.data * timeDelta; // Symplectic Euler
         
         // Estimate external wrench
         extwrench_estimator.JntToExtWrench(q, qd, command_torque, f_tool_estimated);

--- a/orocos_kdl/tests/solvertest.hpp
+++ b/orocos_kdl/tests/solvertest.hpp
@@ -20,6 +20,7 @@
 #include <chaindynparam.hpp>
 #include <chainidsolver_recursive_newton_euler.hpp>
 #include <chainfdsolver_recursive_newton_euler.hpp>
+#include <chainexternalwrenchestimator.hpp>
 #include <utilities/ldl_solver_eigen.hpp>
 
 

--- a/orocos_kdl/tests/solvertest.hpp
+++ b/orocos_kdl/tests/solvertest.hpp
@@ -34,6 +34,7 @@ class SolverTest : public CppUnit::TestFixture
     CPPUNIT_TEST(FkVelAndIkVelTest );
     CPPUNIT_TEST(FkPosAndIkPosTest );
     CPPUNIT_TEST(VereshchaginTest );
+    CPPUNIT_TEST(ExternalWrenchEstimatorTest );
     CPPUNIT_TEST(IkSingularValueTest );
     CPPUNIT_TEST(IkVelSolverWDLSTest );
     CPPUNIT_TEST(FkPosVectTest );
@@ -54,6 +55,7 @@ public:
     void FkVelAndIkVelTest();
     void FkPosAndIkPosTest();
     void VereshchaginTest();
+    void ExternalWrenchEstimatorTest();
     void IkSingularValueTest() ;
     void IkVelSolverWDLSTest();
     void FkPosVectTest();


### PR DESCRIPTION
First-order momentum observer for the estimation of external wrenches applied on the robot's end-effector. 
Implementation based on _S. Haddadin, A. De Luca and A. Albu-Schäffer, ``Robot Collisions: A Survey on Detection, Isolation, and Identification,'' in IEEE Transactions on Robotics, vol. 33(6), pp. 1292-1312, 2017._

The motivation behind this component is discussed in issue #304.