### PR TITLE
(actions) fix industrial CI missing variable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,7 @@ jobs:
     name: Industrial CI - ${{ matrix.env.ROS_DISTRO }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         include:
           - env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,11 +76,13 @@ jobs:
               ROS_DISTRO: kinetic
               ROS_REPO: ros
               ABICHECK_URL: github:orocos/orocos_kinematics_dynamics#release-1.3
+              ABICHECK_MERGE: false
             branch: release-1.3
           - env:
               ROS_DISTRO: melodic
               ROS_REPO: ros
               ABICHECK_URL: github:orocos/orocos_kinematics_dynamics#release-1.4
+              ABICHECK_MERGE: false
             branch: release-1.4
     env: ${{ matrix.env }}
     steps:

--- a/python_orocos_kdl/package.xml
+++ b/python_orocos_kdl/package.xml
@@ -16,6 +16,9 @@
   <buildtool_depend>catkin</buildtool_depend>
 
   <build_depend>orocos_kdl</build_depend>
+  
+  <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
 
   <exec_depend>catkin</exec_depend>
   <exec_depend>orocos_kdl</exec_depend>


### PR DESCRIPTION
Industrial CI doesn't allow missing variables anymore since https://github.com/ros-industrial/industrial_ci/commit/ee6afa6cfb80e3d611c2044f3aeac175b61327f9

It also showed that PyKDL requires a dependency on python(3).

The ABI check should fail, because master isn't compatible with the release branches. But the checks fail again in a correct way:
Push: https://github.com/orocos/orocos_kinematics_dynamics/actions/runs/524170381
PR: https://github.com/orocos/orocos_kinematics_dynamics/actions/runs/524170414