### PR TITLE
(actions) Run multiple python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,9 @@ jobs:
         run: |
           cd python_orocos_kdl
           python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
+          export PYTHONPATH=$(/usr/bin/python -c "import sys; print(':'.join(sys.path))")
           export PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
+          echo $PYTHONPATH
           python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,23 +16,19 @@ jobs:
         orocos_build_type: [Debug, Release]
         compiler: [gcc, clang]
         python_version: ['3.8']
-        python: [python3]
         include:
           - os: ubuntu-18.04
             orocos_build_type: Release
             compiler: gcc
             python_version: '2'
-            python: python
           - os: ubuntu-20.04
             orocos_build_type: Release
             compiler: gcc
             python_version: '3.9'
-            python: python3
     env:
       CC: ${{ matrix.compiler }}
       OROCOS_BUILD_TYPE: ${{ matrix.orocos_build_type }}
       ROS_PYTHON_VERSION: ${{ matrix.python_version }}
-      PYTHON: ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           cd python_orocos_kdl
           which python
-          python tests/PyKDLtest.py
+          LD_LIBRARY_PATH="" python tests/PyKDLtest.py
 
   industrial_ci:
     name: Industrial CI - ${{ matrix.env.ROS_DISTRO }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,11 +69,13 @@ jobs:
           cd orocos_kdl/build
           make check
       - name: Test PyKDL Python
+        env:
+          LD_LIBRARY_PATH: ""
         run: |
           cd python_orocos_kdl
           which python
           env
-          LD_LIBRARY_PATH="" python tests/PyKDLtest.py
+          python tests/PyKDLtest.py
 
   industrial_ci:
     name: Industrial CI - ${{ matrix.env.ROS_DISTRO }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,8 +74,6 @@ jobs:
           cd python_orocos_kdl
           python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
           export PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
-          echo $PYTHONPATH
-          python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py
 
   industrial_ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,11 +28,6 @@ jobs:
             compiler: gcc
             python_version: '3.9'
             python: python3
-          - os: ubuntu-20.04
-            orocos_build_type: Release
-            compiler: gcc
-            python_version: '3.10'
-            python: python3
     env:
       CC: ${{ matrix.compiler }}
       OROCOS_BUILD_TYPE: ${{ matrix.orocos_build_type }}
@@ -76,6 +71,7 @@ jobs:
       - name: Test PyKDL Python
         run: |
           cd python_orocos_kdl
+          which python
           python tests/PyKDLtest.py
 
   industrial_ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-20.04]
         orocos_build_type: [Debug, Release]
         compiler: [gcc, clang]
-        python_version: ['3']
+        python_version: ['3.8']
         python: [python3]
         include:
           - os: ubuntu-18.04
@@ -62,23 +62,17 @@ jobs:
       - name: Update LD_LIBRARY_PATH
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-          sudo ldconfig -v
+          sudo ldconfig
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: Test orocos_kdl
         run: |
           cd orocos_kdl/build
           make check
       - name: Test PyKDL
-        env:
-          LD_LIBRARY_PATH: ""
         run: |
           cd python_orocos_kdl
-          which python
-          env
-          sudo ldconfig -v
-          env
-          python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))"
-          python -c "import sys; print(sys.path)"
+          python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))"
+          PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
           python tests/PyKDLtest.py
 
   industrial_ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
         run: |
           cd python_orocos_kdl
           which python
+          env
           LD_LIBRARY_PATH="" python tests/PyKDLtest.py
 
   industrial_ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,6 @@ jobs:
           cd python_orocos_kdl
           python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
           export PYTHONPATH=$(/usr/bin/python -c "import sys; print(':'.join(sys.path))")
-          export PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
           echo $PYTHONPATH
           python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Update LD_LIBRARY_PATH
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-          sudo ldconfig
+          sudo ldconfig -v
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: Test orocos_kdl
         run: |
@@ -74,6 +74,8 @@ jobs:
         run: |
           cd python_orocos_kdl
           which python
+          env
+          sudo ldconfig -v
           env
           python tests/PyKDLtest.py
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
           cmake -DENABLE_TESTS:BOOL=ON -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
           make
           sudo make install
-      - name: Build PyKDL Python
+      - name: Build PyKDL
         run: |
           cd python_orocos_kdl
           mkdir build
@@ -68,7 +68,7 @@ jobs:
         run: |
           cd orocos_kdl/build
           make check
-      - name: Test PyKDL Python
+      - name: Test PyKDL
         env:
           LD_LIBRARY_PATH: ""
         run: |
@@ -77,6 +77,7 @@ jobs:
           env
           sudo ldconfig -v
           env
+          python -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(plat_specific=True, prefix=''))"
           python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,22 +8,33 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-18.04
+    runs-on:  ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-20.04]
         orocos_build_type: [Debug, Release]
         compiler: [gcc, clang]
+        ros_python_version: [3]
+        python: [python3]
+        include:
+          - os: ubuntu-18.04
+            orocos_build_type: Release
+            compiler: gcc
+            ros_python_version: 2
+            python: python
     env:
       CC: ${{ matrix.compiler }}
       OROCOS_BUILD_TYPE: ${{ matrix.orocos_build_type }}
+      ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
+      PYTHON: ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: Install
         run: |
-          sudo apt-get install libeigen3-dev libcppunit-dev python-psutil python3-psutil python-future python3-future
+          sudo apt-get install libeigen3-dev libcppunit-dev ${PYTHON}-psutil ${PYTHON}-future
       - name: Build orocos_kdl
         run: |
           cd orocos_kdl
@@ -32,21 +43,11 @@ jobs:
           cmake -DENABLE_TESTS:BOOL=ON -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
           make
           sudo make install
-      - name: Build PyKDL Python 2
+      - name: Build PyKDL Python
         run: |
           cd python_orocos_kdl
-          mkdir build2
-          cd build2
-          export ROS_PYTHON_VERSION=2
-          cmake -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
-          make
-          sudo make install
-      - name: Build PyKDL Python 3
-        run: |
-          cd python_orocos_kdl
-          mkdir build3
-          cd build3
-          export ROS_PYTHON_VERSION=3
+          mkdir build
+          cd build
           cmake -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
           make
           sudo make install
@@ -58,14 +59,10 @@ jobs:
         run: |
           cd orocos_kdl/build
           make check
-      - name: Test PyKDL Python 2
+      - name: Test PyKDL Python
         run: |
           cd python_orocos_kdl
-          python2 tests/PyKDLtest.py
-      - name: Test PyKDL Python 3
-        run: |
-          cd python_orocos_kdl
-          python3 tests/PyKDLtest.py
+          ${PYTHON} tests/PyKDLtest.py
 
   industrial_ci:
     name: Industrial CI - ${{ matrix.env.ROS_DISTRO }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,23 +15,36 @@ jobs:
         os: [ubuntu-20.04]
         orocos_build_type: [Debug, Release]
         compiler: [gcc, clang]
-        ros_python_version: [3]
+        python_version: [3]
         python: [python3]
         include:
           - os: ubuntu-18.04
             orocos_build_type: Release
             compiler: gcc
-            ros_python_version: 2
+            python_version: 2
             python: python
+          - os: ubuntu-20.04
+            orocos_build_type: Release
+            compiler: gcc
+            python_version: 3.9
+            python: python3
+          - os: ubuntu-20.04
+            orocos_build_type: Release
+            compiler: gcc
+            python_version: 3.10
+            python: python3
     env:
       CC: ${{ matrix.compiler }}
       OROCOS_BUILD_TYPE: ${{ matrix.orocos_build_type }}
-      ROS_PYTHON_VERSION: ${{ matrix.ros_python_version }}
+      ROS_PYTHON_VERSION: ${{ matrix.python_version }}
       PYTHON: ${{ matrix.python }}
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
       - name: Install
         run: |
           sudo apt-get install libeigen3-dev libcppunit-dev ${PYTHON}-psutil ${PYTHON}-future

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,6 +73,7 @@ jobs:
           cd python_orocos_kdl
           python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
           PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
+          python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py
 
   industrial_ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,8 +71,7 @@ jobs:
       - name: Test PyKDL
         run: |
           cd python_orocos_kdl
-          python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
-          export PYTHONPATH=$(/usr/bin/python -c "import sys; print(':'.join(sys.path))")
+          export PYTHONPATH=$(python -c "import sys; print(':'.join(sys.path))"):$(/usr/bin/python -c "import sys; print(':'.join(sys.path))")
           echo $PYTHONPATH
           python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,23 +15,23 @@ jobs:
         os: [ubuntu-20.04]
         orocos_build_type: [Debug, Release]
         compiler: [gcc, clang]
-        python_version: [3]
+        python_version: ['3']
         python: [python3]
         include:
           - os: ubuntu-18.04
             orocos_build_type: Release
             compiler: gcc
-            python_version: 2
+            python_version: '2'
             python: python
           - os: ubuntu-20.04
             orocos_build_type: Release
             compiler: gcc
-            python_version: 3.9
+            python_version: '3.9'
             python: python3
           - os: ubuntu-20.04
             orocos_build_type: Release
             compiler: gcc
-            python_version: 3.10
+            python_version: '3.10'
             python: python3
     env:
       CC: ${{ matrix.compiler }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,8 @@ jobs:
           python-version: ${{ matrix.python_version }}
       - name: Install
         run: |
-          sudo apt-get install libeigen3-dev libcppunit-dev ${PYTHON}-psutil ${PYTHON}-future
+          sudo apt-get install libeigen3-dev libcppunit-dev
+          pip install psutil future
       - name: Build orocos_kdl
         run: |
           cd orocos_kdl
@@ -71,8 +72,8 @@ jobs:
       - name: Test PyKDL
         run: |
           cd python_orocos_kdl
-          python -c "import sys; print(sys.path)"
-          export PYTHONPATH=$(python -c "import sys; print(':'.join(sys.path))"):$(/usr/bin/python -c "import sys; print(':'.join(sys.path))")
+          python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
+          export PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
           echo $PYTHONPATH
           python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,11 +56,8 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=${OROCOS_KDL_BUILD_TYPE} ./..
           make
           sudo make install
-      - name: Update LD_LIBRARY_PATH
-        run: |
-          export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
-          sudo ldconfig
-          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
+      - name: ldconfig
+        run: sudo ldconfig
       - name: Test orocos_kdl
         run: |
           cd orocos_kdl/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,6 +77,7 @@ jobs:
           env
           sudo ldconfig -v
           env
+          python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py
 
   industrial_ci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,7 +61,7 @@ jobs:
           sudo make install
       - name: Update LD_LIBRARY_PATH
         run: |
-          export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+          export LD_LIBRARY_PATH=/usr/local/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}
           sudo ldconfig
           echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: Test orocos_kdl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Test PyKDL Python
         run: |
           cd python_orocos_kdl
-          ${PYTHON} tests/PyKDLtest.py
+          python tests/PyKDLtest.py
 
   industrial_ci:
     name: Industrial CI - ${{ matrix.env.ROS_DISTRO }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Test PyKDL
         run: |
           cd python_orocos_kdl
+          python -c "import sys; print(sys.path)"
           export PYTHONPATH=$(python -c "import sys; print(':'.join(sys.path))"):$(/usr/bin/python -c "import sys; print(':'.join(sys.path))")
           echo $PYTHONPATH
           python -c "import sys; print(sys.path)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Test PyKDL
         run: |
           cd python_orocos_kdl
-          python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))"
+          python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
           PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
           python tests/PyKDLtest.py
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,7 @@ jobs:
         run: |
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
           sudo ldconfig
+          echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH" >> $GITHUB_ENV
       - name: Test orocos_kdl
         run: |
           cd orocos_kdl/build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
         run: |
           cd python_orocos_kdl
           python_version_short=$(python -c "import sys; print('{}.{}'.format(sys.version_info[0], sys.version_info[1]))")
-          PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
+          export PYTHONPATH=/usr/local/lib/python${python_version_short}/dist-packages${PYTHONPATH:+:${PYTHONPATH}}
           python -c "import sys; print(sys.path)"
           python tests/PyKDLtest.py
 


### PR DESCRIPTION
- Only run 1 job with python2
- Run all python3 jobs on ubuntu 20.04
- Run 4 jobs on default python version, which is 3.8 for ubuntu 20.04
- Run 1 job per other version, for now only 3.9

I think we should squash this PR.