### PR TITLE
Add degraded status chainiksolverpos

### DIFF
--- a/orocos_kdl/src/chainiksolverpos_nr.hpp
+++ b/orocos_kdl/src/chainiksolverpos_nr.hpp
@@ -73,6 +73,47 @@ namespace KDL {
          */
         virtual int CartToJnt(const JntArray& q_init, const Frame& p_in, JntArray& q_out);
 
+        /**
+         * Set maximum number of iterations
+         */
+        void setMaxIter(const unsigned int maxiter_in);
+
+        /**
+         * Set epsilon
+         * \pre 0 < eps, otherwise eps is ignored
+         */
+        void setEps(const double eps_in);
+
+        /**
+         * Get maximum number of iterations
+         * \pre 1 <= maxiter, otherwise maxiter is ignored
+         */
+        unsigned int getMaxIter()const { return maxiter; }
+
+        /**
+         * Get epsilon
+         */
+        double getEps()const { return eps; }
+
+        /**
+         * Get delta twist from last call to CartToJnt()
+         */
+        void getDeltaTwist(KDL::Twist& _delta_twist)
+        {
+            _delta_twist    = delta_twist;
+        }
+
+        /**
+         * Get status of ik velocity solver
+         */
+        int getVelSolverStatus() const { return ikvelstatus; }
+
+        /**
+         * Get number iterations spent in last call to CartToJnt()
+         * Defaults to 0 at construction
+         */
+        unsigned int getNumIters() const { return numiter; }
+
         /// @copydoc KDL::SolverI::strError()
         virtual const char* strError(const int error) const;
 
@@ -90,6 +131,8 @@ namespace KDL {
 
         unsigned int maxiter;
         double eps;
+        unsigned int numiter;
+        int ikvelstatus;
     };
 
 }

--- a/orocos_kdl/tests/solvertest.cpp
+++ b/orocos_kdl/tests/solvertest.cpp
@@ -576,7 +576,7 @@ void SolverTest::IkSingularValueTest()
 	CPPUNIT_ASSERT_EQUAL(0, fksolver.JntToCart(q,F));
 	F_des = F * dF ;
 
-	CPPUNIT_ASSERT_EQUAL((int)SolverI::E_MAX_ITERATIONS_EXCEEDED,
+	CPPUNIT_ASSERT_EQUAL((int)SolverI::E_DEGRADED,
                          iksolver1.CartToJnt(q,F_des,q_solved)); // no converge
 	CPPUNIT_ASSERT_EQUAL((int)ChainIkSolverVel_pinv::E_CONVERGE_PINV_SINGULAR,
                          ikvelsolver1.getError());        	// truncated SV solution
@@ -627,7 +627,7 @@ void SolverTest::IkSingularValueTest()
     CPPUNIT_ASSERT_EQUAL((int)SolverI::E_NOERROR, fksolver.JntToCart(q,F));
     F_des = F * dF ;
 
-    CPPUNIT_ASSERT_EQUAL((int)SolverI::E_MAX_ITERATIONS_EXCEEDED,
+    CPPUNIT_ASSERT_EQUAL((int)SolverI::E_DEGRADED,
                          iksolver1.CartToJnt(q,F_des,q_solved)); // no converge
     CPPUNIT_ASSERT_EQUAL((int)ChainIkSolverVel_pinv::E_CONVERGE_PINV_SINGULAR,
                          ikvelsolver1.getError());        	// truncated SV solution


### PR DESCRIPTION
The nr position solver currently produces a non-convergence error if the Cartesian pose does not converge to the desired value within the specified maximum number of iterations.  However, the lack of convergence could be due to the singularity avoidance being active leaving the solver in a "degraded" state so that it cannot achieve the desired pose.  This commit adds a degraded flag which is checked when the maximum number of iterations is reached.  If it is degraded, then the solver error is set to E_DEGRADED and the user can then decide whether it should be allowed to continue.  Otherwise, the error is set to E_MAX_ITERATIONS_EXCEEDED which would normally terminate the process.  In addition, functions were added to set/get the input parameters (maxiter,eps) and retrieve other data from the solver (twist error, number of iterations, velocity solver status).