### PR TITLE
Fix Python bindings for static member functions Frme::DH() and Frame::DH_Craig1989()

### DIFF
--- a/orocos_kdl/tests/CMakeLists.txt
+++ b/orocos_kdl/tests/CMakeLists.txt
@@ -8,64 +8,64 @@ IF(ENABLE_TESTS)
   SET(TESTNAME "framestest")
   SET_TARGET_PROPERTIES( framestest PROPERTIES
    COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
-  ADD_TEST(framestest framestest)
+  ADD_TEST(NAME framestest COMMAND framestest)
 
  ADD_EXECUTABLE(kinfamtest kinfamtest.cpp test-runner.cpp)
  TARGET_LINK_LIBRARIES(kinfamtest orocos-kdl ${CPPUNIT})
  SET(TESTNAME "kinfamtest")
  SET_TARGET_PROPERTIES( kinfamtest PROPERTIES
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS}")
- ADD_TEST(kinfamtest kinfamtest)
+ ADD_TEST(NAME kinfamtest COMMAND kinfamtest)
 
  ADD_EXECUTABLE(solvertest solvertest.cpp test-runner.cpp)
  TARGET_LINK_LIBRARIES(solvertest orocos-kdl ${CPPUNIT})
  SET(TESTNAME "solvertest")
  SET_TARGET_PROPERTIES( solvertest PROPERTIES
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
- ADD_TEST(solvertest solvertest)
+ ADD_TEST(NAME solvertest COMMAND solvertest)
 
  ADD_EXECUTABLE(inertiatest inertiatest.cpp test-runner.cpp)
  TARGET_LINK_LIBRARIES(inertiatest orocos-kdl ${CPPUNIT})
  SET(TESTNAME "inertiatest")
  SET_TARGET_PROPERTIES( inertiatest PROPERTIES
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
- ADD_TEST(inertiatest inertiatest)
+ ADD_TEST(NAME inertiatest COMMAND inertiatest)
 
  ADD_EXECUTABLE(jacobiantest jacobiantest.cpp test-runner.cpp)
  SET(TESTNAME "jacobiantest")
  TARGET_LINK_LIBRARIES(jacobiantest orocos-kdl ${CPPUNIT})
  SET_TARGET_PROPERTIES( jacobiantest PROPERTIES
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
- ADD_TEST(jacobiantest jacobiantest)
+ ADD_TEST(NAME jacobiantest COMMAND jacobiantest)
 
  ADD_EXECUTABLE(jacobiandottest jacobiandottest.cpp test-runner.cpp)
  SET(TESTNAME "jacobiandottest")
  TARGET_LINK_LIBRARIES(jacobiandottest orocos-kdl ${CPPUNIT})
  SET_TARGET_PROPERTIES( jacobiandottest PROPERTIES
   COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
- ADD_TEST(jacobiandottest jacobiandottest)
+ ADD_TEST(NAME jacobiandottest COMMAND jacobiandottest)
 
  ADD_EXECUTABLE(velocityprofiletest velocityprofiletest.cpp test-runner.cpp)
  SET(TESTNAME "velocityprofiletest")
  TARGET_LINK_LIBRARIES(velocityprofiletest orocos-kdl ${CPPUNIT})
  SET_TARGET_PROPERTIES( velocityprofiletest PROPERTIES
    COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
- ADD_TEST(velocityprofiletest velocityprofiletest)
+ ADD_TEST(NAME velocityprofiletest COMMAND velocityprofiletest)
 
  ADD_EXECUTABLE(treeinvdyntest treeinvdyntest.cpp test-runner.cpp)
  SET(TESTNAME "treeinvdyntest")
  TARGET_LINK_LIBRARIES(treeinvdyntest orocos-kdl ${CPPUNIT})
  SET_TARGET_PROPERTIES( treeinvdyntest PROPERTIES
    COMPILE_FLAGS "${CMAKE_CXX_FLAGS_ADD} ${KDL_CFLAGS} -DTESTNAME=\"\\\"${TESTNAME}\\\"\" ")
- ADD_TEST(treeinvdyntest treeinvdyntest)
+ ADD_TEST(NAME treeinvdyntest COMMAND treeinvdyntest)
 
 #  ADD_EXECUTABLE(rframestest  rframestest.cpp)
 #  TARGET_LINK_LIBRARIES(rframestest orocos-kdl)
-#  ADD_TEST(rframestest rframestest)
+#  ADD_TEST(NAME rframestest COMMAND rframestest)
 #
 #  ADD_EXECUTABLE(rallnumbertest  rallnumbertest.cpp)
 #  TARGET_LINK_LIBRARIES(rallnumbertest orocos-kdl)
-#  ADD_TEST(rallnumbertest rallnumbertest)
+#  ADD_TEST(NAME rallnumbertest COMMAND rallnumbertest)
 
   ADD_CUSTOM_TARGET(check ctest -V WORKING_DIRECTORY ${PROJ_BINARY_DIR}/tests)
 ENDIF(ENABLE_TESTS)

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -635,18 +635,19 @@ void FramesTest::TestFrame() {
 	CPPUNIT_ASSERT_EQUAL(F.Inverse()*v,F.Inverse(v));
 
 	// Denavit-Hartenberg
-	CPPUNIT_ASSERT(Equal(
-		Frame::DH(0.0, M_PI_2, 0.36, 0.0),
-		Frame(Rotation(1, 0, 0,
-		               0, 0, -1,
-		               0, 1, 0),
-		      Vector(0, 0, 0.36))));
-	CPPUNIT_ASSERT(Equal(
-		Frame::DH_Craig1989(0.0, M_PI_2, 0.36, 0.0),
-		Frame(Rotation(1, 0, 0,
-		               0, 0, -1,
-		               0, 1, 0),
-		      Vector(0, -0.36, 0))));
+    Frame F_DH = Frame(Rotation(1, 0, 0,
+                          0, 0, -1,
+                          0, 1, 0),
+                 Vector(0, 0, 0.36));
+    CPPUNIT_ASSERT(Equal(Frame::DH(0.0, M_PI_2, 0.36, 0.0), F_DH));
+    CPPUNIT_ASSERT(Equal(Frame().DH(0.0, M_PI_2, 0.36, 0.0), F_DH));
+
+    Frame F_DH_Craig1989 = Frame(Rotation(1, 0, 0,
+                                          0, 0, -1,
+                                          0, 1, 0),
+                                 Vector(0, -0.36, 0));
+    CPPUNIT_ASSERT(Equal(Frame::DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989));
+    CPPUNIT_ASSERT(Equal(Frame().DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989));
 }
 
 JntArray CreateRandomJntArray(int size)

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -633,6 +633,20 @@ void FramesTest::TestFrame() {
 	CPPUNIT_ASSERT_EQUAL(F*F.Inverse(),Frame::Identity());
 	CPPUNIT_ASSERT_EQUAL(F.Inverse()*F,Frame::Identity());
 	CPPUNIT_ASSERT_EQUAL(F.Inverse()*v,F.Inverse(v));
+
+	// Denavit-Hartenberg
+	CPPUNIT_ASSERT(Equal(
+		Frame::DH(0.0, M_PI_2, 0.36, 0.0),
+		Frame(Rotation(1, 0, 0,
+		               0, 0, -1,
+		               0, 1, 0),
+		      Vector(0, 0, 0.36))));
+	CPPUNIT_ASSERT(Equal(
+		Frame::DH_Craig1989(0.0, M_PI_2, 0.36, 0.0),
+		Frame(Rotation(1, 0, 0,
+		               0, 0, -1,
+		               0, 1, 0),
+		      Vector(0, -0.36, 0))));
 }
 
 JntArray CreateRandomJntArray(int size)

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -640,14 +640,14 @@ void FramesTest::TestFrame() {
                           0, 1, 0),
                  Vector(0, 0, 0.36));
     CPPUNIT_ASSERT(Equal(Frame::DH(0.0, M_PI_2, 0.36, 0.0), F_DH));
-    CPPUNIT_ASSERT(Equal(Frame().DH(0.0, M_PI_2, 0.36, 0.0), F_DH));
+    CPPUNIT_ASSERT(Equal(Frame().DH(0.0, M_PI_2, 0.36, 0.0), F_DH)); // Only for testing purposes, shouldn't use static function of instances
 
     Frame F_DH_Craig1989 = Frame(Rotation(1, 0, 0,
                                           0, 0, -1,
                                           0, 1, 0),
                                  Vector(0, -0.36, 0));
     CPPUNIT_ASSERT(Equal(Frame::DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989));
-    CPPUNIT_ASSERT(Equal(Frame().DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989));
+    CPPUNIT_ASSERT(Equal(Frame().DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989)); // Only for testing purposes, shouldn't use static function of instances
 }
 
 JntArray CreateRandomJntArray(int size)

--- a/python_orocos_kdl/PyKDL/frames.cpp
+++ b/python_orocos_kdl/PyKDL/frames.cpp
@@ -436,8 +436,8 @@ void init_frames(py::module &m)
     {
         return Frame(self);
     }, py::arg("memo"));
-    frame.def("DH_Craig1989", &Frame::DH_Craig1989);
-    frame.def("DH", &Frame::DH);
+    frame.def_static("DH_Craig1989", &Frame::DH_Craig1989);
+    frame.def_static("DH", &Frame::DH);
     frame.def("Inverse", (Frame (Frame::*)() const) &Frame::Inverse);
     frame.def("Inverse", (Vector (Frame::*)(const Vector&) const) &Frame::Inverse);
     frame.def("Inverse", (Wrench (Frame::*)(const Wrench&) const) &Frame::Inverse);

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -347,19 +347,19 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertEqual(Frame(f).p, f.p)
 
         # Denavit-Hartenberg
-        f = Frame.DH(0.0, pi/2, 0.36, 0.0)
-        self.assertTrue(Equal(
-            Frame.DH(0.0, pi/2, 0.36, 0.0),
-            Frame(Rotation(1, 0, 0,
-                           0, 0, -1,
-                           0, 1, 0),
-                  Vector(0, 0, 0.36))))
-        self.assertTrue(Equal(
-            Frame.DH_Craig1989(0.0, pi/2, 0.36, 0.0),
-            Frame(Rotation(1, 0, 0,
-                           0, 0, -1,
-                           0, 1, 0),
-                  Vector(0, -0.36, 0))))
+        f_dh = Frame(Rotation(1, 0, 0,
+                              0, 0, -1,
+                              0, 1, 0),
+                     Vector(0, 0, 0.36))
+        self.assertTrue(Equal(Frame.DH(0.0, pi/2, 0.36, 0.0), f_dh))
+        self.assertTrue(Equal(Frame().DH(0.0, pi/2, 0.36, 0.0), f_dh))
+
+        f_dh_craig1989 = Frame(Rotation(1, 0, 0,
+                                        0, 0, -1,
+                                        0, 1, 0),
+                               Vector(0, -0.36, 0))
+        self.assertTrue(Equal(Frame.DH_Craig1989(0.0, pi/2, 0.36, 0.0), f_dh_craig1989))
+        self.assertTrue(Equal(Frame().DH_Craig1989(0.0, pi / 2, 0.36, 0.0), f_dh_craig1989))
 
         f = Frame(Rotation(1, 2, 3,
                            5, 6, 7,

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -352,6 +352,7 @@ class FramesTestFunctions(unittest.TestCase):
                               0, 1, 0),
                      Vector(0, 0, 0.36))
         self.assertTrue(Equal(Frame.DH(0.0, pi/2, 0.36, 0.0), f_dh))
+        # Only for testing purposes, shouldn't use static function of instances
         self.assertTrue(Equal(Frame().DH(0.0, pi/2, 0.36, 0.0), f_dh))
 
         f_dh_craig1989 = Frame(Rotation(1, 0, 0,
@@ -359,6 +360,7 @@ class FramesTestFunctions(unittest.TestCase):
                                         0, 1, 0),
                                Vector(0, -0.36, 0))
         self.assertTrue(Equal(Frame.DH_Craig1989(0.0, pi/2, 0.36, 0.0), f_dh_craig1989))
+        # Only for testing purposes, shouldn't use static function of instances
         self.assertTrue(Equal(Frame().DH_Craig1989(0.0, pi / 2, 0.36, 0.0), f_dh_craig1989))
 
         f = Frame(Rotation(1, 2, 3,

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -22,7 +22,7 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 
-from math import radians, sqrt
+from math import pi, radians, sqrt
 from PyKDL import *
 import sys
 import unittest
@@ -345,6 +345,21 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertEqual(f.p, v2)
         self.assertEqual(Frame(f).M, f.M)
         self.assertEqual(Frame(f).p, f.p)
+
+        # Denavit-Hartenberg
+        f = Frame.DH(0.0, pi/2, 0.36, 0.0)
+        self.assertTrue(Equal(
+            Frame.DH(0.0, pi/2, 0.36, 0.0),
+            Frame(Rotation(1, 0, 0,
+                           0, 0, -1,
+                           0, 1, 0),
+                  Vector(0, 0, 0.36))))
+        self.assertTrue(Equal(
+            Frame.DH_Craig1989(0.0, pi/2, 0.36, 0.0),
+            Frame(Rotation(1, 0, 0,
+                           0, 0, -1,
+                           0, 1, 0),
+                  Vector(0, -0.36, 0))))
 
         f = Frame(Rotation(1, 2, 3,
                            5, 6, 7,


### PR DESCRIPTION
Those are static member functions of `KDL::Frame` and hence need to be declared to pybind11 with `def_static()` instead of `def()`:

https://github.com/orocos/orocos_kinematics_dynamics/blob/a789adafa8d09f9d098810b4f9b845fc1a77f389/orocos_kdl/src/frames.hpp#L647-L701

Before:
```py
>>> import PyKDL
>>> PyKDL.Frame().DH_Craig1989(0.,0.,0.,0.)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: DH_Craig1989(): incompatible function arguments. The following argument types are supported:
    1. (self: float, arg0: float, arg1: float, arg2: float) -> PyKDL.Frame

Invoked with: [[           1,           0,           0;
            0,           1,           0;
            0,           0,           1]
[           0,           0,           0]], 0.0, 0.0, 0.0, 0.0
```

With this patch:
```py
>>> import PyKDL
>>> PyKDL.Frame().DH_Craig1989(0.,0.,0.,0.)
[[           1,          -0,           0;
            0,           1,          -0;
            0,           0,           1]
[           0,          -0,           0]]
>>> PyKDL.Frame.DH_Craig1989(0.,0.,0.,0.)
[[           1,          -0,           0;
            0,           1,          -0;
            0,           0,           1]
[           0,          -0,           0]]
>>> 

```