### PR TITLE
Fix not implemented errors

### DIFF
--- a/orocos_kdl/src/chainiksolvervel_pinv.hpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv.hpp
@@ -77,7 +77,7 @@ namespace KDL
          * not (yet) implemented.
          *
          */
-        virtual int CartToJnt(const JntArray& /*q_init*/, const FrameVel& /*v_in*/, JntArrayVel& /*q_out*/){return -1;};
+        virtual int CartToJnt(const JntArray& /*q_init*/, const FrameVel& /*v_in*/, JntArrayVel& /*q_out*/){return (error = E_NOT_IMPLEMENTED);};
 
         /**
          * Retrieve the number of singular values of the jacobian that are < eps;

--- a/orocos_kdl/src/chainiksolvervel_pinv_nso.hpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv_nso.hpp
@@ -69,7 +69,7 @@ namespace KDL
          * not (yet) implemented.
          *
          */
-        virtual int CartToJnt(const JntArray& /*q_init*/, const FrameVel& /*v_in*/, JntArrayVel& /*q_out*/){return -1;};
+        virtual int CartToJnt(const JntArray& /*q_init*/, const FrameVel& /*v_in*/, JntArrayVel& /*q_out*/){return (error = E_NOT_IMPLEMENTED);};
 
         /**
          * Request the joint weights for optimization criterion

--- a/python_orocos_kdl/PyKDL/kinfam.cpp
+++ b/python_orocos_kdl/PyKDL/kinfam.cpp
@@ -382,7 +382,7 @@ void init_kinfam(pybind11::module &m)
     py::class_<ChainIkSolverVel, SolverI> chain_ik_solver_vel(m, "ChainIkSolverVel");
     chain_ik_solver_vel.def("CartToJnt", (int (ChainIkSolverVel::*)(const JntArray&, const Twist&, JntArray&)) &ChainIkSolverVel::CartToJnt,
                             py::arg("q_in"), py::arg("v_in"), py::arg("qdot_out"));
-//    Argument by reference doesn't work for container types
+//    Not yet implemented in orocos_kdl
 //    chain_ik_solver_vel.def("CartToJnt", (int (ChainIkSolverVel::*)(const JntArray&, const FrameVel&, JntArrayVel&)) &ChainIkSolverVel::CartToJnt,
 //                            py::arg("q_init"), py::arg("v_in"), py::arg("q_out"));
 


### PR DESCRIPTION
It was already correctly implemented in `ChainIkSolverVel_pinv_givens`, but not in the other related solvers.