### PR TITLE
Follow-up of "Get rid of using std namespace"

### DIFF
--- a/orocos_kdl/models/kukaLWRtestDHnew.cpp
+++ b/orocos_kdl/models/kukaLWRtestDHnew.cpp
@@ -109,7 +109,7 @@ int getInputs(JntArray &_q, JntArray &_qdot, JntArray &_qdotdot, int &linenr)
    *READING Qdot = joint velocities
    */
   counter=0;//reset counter
-  ifstream inQdotfile("interpreteerbaar/qdot", std::ios::in);
+  std::ifstream inQdotfile("interpreteerbaar/qdot", std::ios::in);
 
   if (!inQdotfile)
   {


### PR DESCRIPTION
at https://github.com/orocos/orocos_kinematics_dynamics/commit/98bc4b597acd189771077ece5f7516694a424784

Downstream issue: https://bugs.gentoo.org/show_bug.cgi?id=821613