### PR TITLE
Skip building pybind11 if already available on system

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -46,7 +46,13 @@ else()
   set(PYTHON_MODULE_EXTENSION ".so")
 endif()
 
-add_subdirectory(pybind11)
+find_package(pybind11 QUIET)
+if(NOT ${pybind11_FOUND})
+  message(STATUS "pybind11 not found, building from source")
+  add_subdirectory(pybind11)
+else()
+  message(STATUS "pybind11 found, building against found version")
+endif()
 pybind11_add_module(${LIBRARY_NAME}
   PyKDL/PyKDL.h
   PyKDL/PyKDL.cpp

--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -51,7 +51,7 @@ if(NOT ${pybind11_FOUND})
   message(STATUS "pybind11 not found, building from source")
   add_subdirectory(pybind11)
 else()
-  message(STATUS "pybind11 found, building against found version")
+  message(STATUS "pybind11 found, building against installed version")
 endif()
 pybind11_add_module(${LIBRARY_NAME}
   PyKDL/PyKDL.h


### PR DESCRIPTION
For example, ROS 2 currently ships with a version of pybind11 that we can use instead of building another version from source.