### PR TITLE
Remove CMake warning related to minimum version

### DIFF
--- a/orocos_kdl/src/CMakeLists.txt
+++ b/orocos_kdl/src/CMakeLists.txt
@@ -16,42 +16,37 @@ ENDIF(MSVC)
 CONFIGURE_FILE(config.h.in config.h @ONLY)
 
 #### Settings for rpath
-IF(${CMAKE_MINIMUM_REQUIRED_VERSION} VERSION_GREATER "2.8.12")
-    MESSAGE(AUTHOR_WARNING "CMAKE_MINIMUM_REQUIRED_VERSION is now ${CMAKE_MINIMUM_REQUIRED_VERSION}. This check can be removed.")
-ENDIF()
-IF(NOT (CMAKE_VERSION VERSION_LESS 2.8.12))
-    IF(NOT MSVC)
-        #add the option to disable RPATH
-        OPTION(OROCOSKDL_ENABLE_RPATH "Enable RPATH during installation" TRUE)
-        MARK_AS_ADVANCED(OROCOSKDL_ENABLE_RPATH)
-    ENDIF(NOT MSVC)
+IF(NOT MSVC)
+    #add the option to disable RPATH
+    OPTION(OROCOSKDL_ENABLE_RPATH "Enable RPATH during installation" TRUE)
+    MARK_AS_ADVANCED(OROCOSKDL_ENABLE_RPATH)
+ENDIF(NOT MSVC)
 
-    IF(OROCOSKDL_ENABLE_RPATH)
-        #Configure RPATH
-        SET(CMAKE_MACOSX_RPATH TRUE) #enable RPATH on OSX. This also suppress warnings on CMake >= 3.0
-        # when building, don't use the install RPATH already
-        # (but later on when installing)
-        SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-        #build directory by default is built with RPATH
-        SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+IF(OROCOSKDL_ENABLE_RPATH)
+    #Configure RPATH
+    SET(CMAKE_MACOSX_RPATH TRUE) #enable RPATH on OSX. This also suppress warnings on CMake >= 3.0
+    # when building, don't use the install RPATH already
+    # (but later on when installing)
+    SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+    #build directory by default is built with RPATH
+    SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
 
-        #This is relative RPATH for libraries built in the same project
-        #I assume that the directory is
-        # - install_dir/something for binaries
-        # - install_dir/lib for libraries
-        LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-        IF("${isSystemDir}" STREQUAL "-1")
-            FILE(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_PREFIX}/bin" "${CMAKE_INSTALL_PREFIX}/lib")
-            IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-                SET(CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
-            ELSE()
-                SET(CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
-            ENDIF()
-        ENDIF("${isSystemDir}" STREQUAL "-1")
-        # add the automatically determined parts of the RPATH
-        # which point to directories outside the build tree to the install RPATH
-        SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) #very important!
-    ENDIF()
+    #This is relative RPATH for libraries built in the same project
+    #I assume that the directory is
+    # - install_dir/something for binaries
+    # - install_dir/lib for libraries
+    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    IF("${isSystemDir}" STREQUAL "-1")
+        FILE(RELATIVE_PATH _rel_path "${CMAKE_INSTALL_PREFIX}/bin" "${CMAKE_INSTALL_PREFIX}/lib")
+        IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            SET(CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
+        ELSE()
+            SET(CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
+        ENDIF()
+    ENDIF("${isSystemDir}" STREQUAL "-1")
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) #very important!
 ENDIF()
 #####end RPATH
 
@@ -68,17 +63,9 @@ SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
   )
 
 #### Settings for rpath disabled (back-compatibility)
-IF(${CMAKE_MINIMUM_REQUIRED_VERSION} VERSION_GREATER "2.8.12")
-    MESSAGE(AUTHOR_WARNING "CMAKE_MINIMUM_REQUIRED_VERSION is now ${CMAKE_MINIMUM_REQUIRED_VERSION}. This check can be removed.")
-ENDIF()
-IF(CMAKE_VERSION VERSION_LESS 2.8.12)
+IF(NOT OROCOSKDL_ENABLE_RPATH)
     SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
       INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
-ELSE()
-    IF(NOT OROCOSKDL_ENABLE_RPATH)
-        SET_TARGET_PROPERTIES( orocos-kdl PROPERTIES
-          INSTALL_NAME_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}")
-    ENDIF()
 ENDIF()
 #####end RPATH
 


### PR DESCRIPTION
Since the minimum required version of cmake is now 3.0.2, we now see these warnings to remove conditions.
This commit removes the warnings and conditions that are no longer needed.