### PR TITLE
Fix build warnings on Windows

### DIFF
--- a/orocos_kdl/src/chainiksolvervel_pinv_givens.cpp
+++ b/orocos_kdl/src/chainiksolvervel_pinv_givens.cpp
@@ -30,8 +30,8 @@ namespace KDL
         jnt2jac(chain),
         jac(nj),
         transpose(nj>6),toggle(true),
-        m(max(6,nj)),
-        n(min(6,nj)),
+        m(static_cast<unsigned int>(max(6,nj))),
+        n(static_cast<unsigned int>(min(6,nj))),
         jac_eigen(m,n),
         U(Eigen::MatrixXd::Identity(m,m)),
         V(Eigen::MatrixXd::Identity(n,n)),
@@ -50,8 +50,8 @@ namespace KDL
         jnt2jac.updateInternalDataStructures();
         jac.resize(nj);
         transpose = (nj > 6);
-        m = max(6,nj);
-        n = min(6,nj);
+        m = static_cast<unsigned int>(max(6,nj));
+        n = static_cast<unsigned int>(min(6,nj));
         jac_eigen.conservativeResize(m,n);
         U.conservativeResizeLike(Eigen::MatrixXd::Identity(m,m));
         V.conservativeResizeLike(Eigen::MatrixXd::Identity(n,n));

--- a/orocos_kdl/src/jacobian.cpp
+++ b/orocos_kdl/src/jacobian.cpp
@@ -68,12 +68,12 @@ namespace KDL
 
     unsigned int Jacobian::rows()const
     {
-        return data.rows();
+        return static_cast<unsigned int>(data.rows());
     }
 
     unsigned int Jacobian::columns()const
     {
-        return data.cols();
+        return static_cast<unsigned int>(data.cols());
     }
 
     void SetToZero(Jacobian& jac)

--- a/orocos_kdl/src/jntarray.cpp
+++ b/orocos_kdl/src/jntarray.cpp
@@ -69,12 +69,12 @@ namespace KDL
 
     unsigned int JntArray::rows()const
     {
-        return data.rows();
+        return static_cast<unsigned int>(data.rows());
     }
 
     unsigned int JntArray::columns()const
     {
-        return data.cols();
+        return static_cast<unsigned int>(data.cols());
     }
 
     void Add(const JntArray& src1,const JntArray& src2,JntArray& dest)

--- a/orocos_kdl/src/jntspaceinertiamatrix.cpp
+++ b/orocos_kdl/src/jntspaceinertiamatrix.cpp
@@ -67,12 +67,12 @@ namespace KDL
 
     unsigned int JntSpaceInertiaMatrix::rows()const
     {
-        return data.rows();
+        return static_cast<unsigned int>(data.rows());
     }
 
     unsigned int JntSpaceInertiaMatrix::columns()const
     {
-        return data.cols();
+        return static_cast<unsigned int>(data.cols());
     }
     
 

--- a/orocos_kdl/src/tree.cpp
+++ b/orocos_kdl/src/tree.cpp
@@ -156,8 +156,8 @@ bool Tree::getChain(const std::string& chain_root, const std::string& chain_tip,
     }
 
     // add the segments from the common frame to the tip frame
-    for (int s=static_cast<int>(parents_chain_tip.size())-1; s>-1; s--){
-        chain.addSegment(GetTreeElementSegment(getSegment(parents_chain_tip[s])->second));
+    for (auto rit=parents_chain_tip.rbegin(); rit != parents_chain_tip.rend(); ++rit){
+        chain.addSegment(GetTreeElementSegment(getSegment(*rit)->second));
     }
     return true;
 }

--- a/orocos_kdl/src/tree.cpp
+++ b/orocos_kdl/src/tree.cpp
@@ -156,7 +156,7 @@ bool Tree::getChain(const std::string& chain_root, const std::string& chain_tip,
     }
 
     // add the segments from the common frame to the tip frame
-    for (int s=parents_chain_tip.size()-1; s>-1; s--){
+    for (int s=static_cast<int>(parents_chain_tip.size())-1; s>-1; s--){
         chain.addSegment(GetTreeElementSegment(getSegment(parents_chain_tip[s])->second));
     }
     return true;

--- a/orocos_kdl/src/treeiksolverpos_online.cpp
+++ b/orocos_kdl/src/treeiksolverpos_online.cpp
@@ -35,9 +35,6 @@ TreeIkSolverPos_Online::TreeIkSolverPos_Online(const double& nr_of_jnts,
                                                const double x_dot_rot_max,
                                                TreeFkSolverPos& fksolver,
                                                TreeIkSolverVel& iksolver) :
-                                               q_min_(static_cast<unsigned int>(nr_of_jnts)),
-                                               q_max_(static_cast<unsigned int>(nr_of_jnts)),
-                                               q_dot_max_(static_cast<unsigned int>(nr_of_jnts)),
                                                fksolver_(fksolver),
                                                iksolver_(iksolver),
                                                q_dot_(static_cast<unsigned int>(nr_of_jnts))

--- a/orocos_kdl/src/treeiksolverpos_online.cpp
+++ b/orocos_kdl/src/treeiksolverpos_online.cpp
@@ -26,7 +26,7 @@
 
 namespace KDL {
 
-TreeIkSolverPos_Online::TreeIkSolverPos_Online(const double& nr_of_jnts,
+TreeIkSolverPos_Online::TreeIkSolverPos_Online(const unsigned int& nr_of_jnts,
                                                const std::vector<std::string>& endpoints,
                                                const JntArray& q_min,
                                                const JntArray& q_max,

--- a/orocos_kdl/src/treeiksolverpos_online.cpp
+++ b/orocos_kdl/src/treeiksolverpos_online.cpp
@@ -26,7 +26,7 @@
 
 namespace KDL {
 
-TreeIkSolverPos_Online::TreeIkSolverPos_Online(const unsigned int& nr_of_jnts,
+TreeIkSolverPos_Online::TreeIkSolverPos_Online(const double& nr_of_jnts,
                                                const std::vector<std::string>& endpoints,
                                                const JntArray& q_min,
                                                const JntArray& q_max,
@@ -35,12 +35,12 @@ TreeIkSolverPos_Online::TreeIkSolverPos_Online(const unsigned int& nr_of_jnts,
                                                const double x_dot_rot_max,
                                                TreeFkSolverPos& fksolver,
                                                TreeIkSolverVel& iksolver) :
-                                               q_min_(nr_of_jnts),
-                                               q_max_(nr_of_jnts),
-                                               q_dot_max_(nr_of_jnts),
+                                               q_min_(static_cast<unsigned int>(nr_of_jnts)),
+                                               q_max_(static_cast<unsigned int>(nr_of_jnts)),
+                                               q_dot_max_(static_cast<unsigned int>(nr_of_jnts)),
                                                fksolver_(fksolver),
                                                iksolver_(iksolver),
-                                               q_dot_(nr_of_jnts)
+                                               q_dot_(static_cast<unsigned int>(nr_of_jnts))
 {
     q_min_ = q_min;
     q_max_ = q_max;

--- a/orocos_kdl/src/treeiksolverpos_online.hpp
+++ b/orocos_kdl/src/treeiksolverpos_online.hpp
@@ -61,7 +61,7 @@ public:
      * @return
      */
 
-    TreeIkSolverPos_Online(const double& nr_of_jnts,
+    TreeIkSolverPos_Online(const unsigned int& nr_of_jnts,
                            const std::vector<std::string>& endpoints,
                            const JntArray& q_min,
                            const JntArray& q_max,

--- a/orocos_kdl/src/treeiksolverpos_online.hpp
+++ b/orocos_kdl/src/treeiksolverpos_online.hpp
@@ -61,7 +61,7 @@ public:
      * @return
      */
 
-    TreeIkSolverPos_Online(const unsigned int& nr_of_jnts,
+    TreeIkSolverPos_Online(const double& nr_of_jnts,
                            const std::vector<std::string>& endpoints,
                            const JntArray& q_min,
                            const JntArray& q_max,

--- a/orocos_kdl/src/utilities/error_stack.cxx
+++ b/orocos_kdl/src/utilities/error_stack.cxx
@@ -57,7 +57,11 @@ void IOTracePopStr(char* buffer,int size) {
         *buffer = 0;
         return;
     }
+#if defined(_WIN32)
+    strncpy_s(buffer,size,errorstack.top().c_str(),size);
+#else
     strncpy(buffer,errorstack.top().c_str(),size);
+#endif
     buffer[size - 1] = '\0';
     errorstack.pop();
 }

--- a/orocos_kdl/src/utilities/ldl_solver_eigen.cpp
+++ b/orocos_kdl/src/utilities/ldl_solver_eigen.cpp
@@ -25,7 +25,7 @@ namespace KDL{
 
     int ldl_solver_eigen(const Eigen::MatrixXd& A, const Eigen::VectorXd& v, Eigen::MatrixXd& L, Eigen::VectorXd& D, Eigen::VectorXd& vtmp, Eigen::VectorXd& q)
     {
-        const int n = A.rows();
+        const int n = static_cast<int>(A.rows());
         int error=SolverI::E_NOERROR;
 
         //Check sizes

--- a/orocos_kdl/src/utilities/svd_eigen_HH.cpp
+++ b/orocos_kdl/src/utilities/svd_eigen_HH.cpp
@@ -26,8 +26,8 @@ namespace KDL{
     int svd_eigen_HH(const Eigen::MatrixXd &A, Eigen::MatrixXd &U, Eigen::VectorXd &S, Eigen::MatrixXd &V, Eigen::VectorXd &tmp, int maxiter, double epsilon)
     {
         //get the rows/columns of the matrix
-        const int rows = A.rows();
-        const int cols = A.cols();
+        const int rows = static_cast<int>(A.rows());
+        const int cols = static_cast<int>(A.cols());
     
         U.setZero();
         U.topLeftCorner(rows,cols)=A;


### PR DESCRIPTION
We noticed these warnings when building orocos_kdl as part of ROS 2 CI, see https://ci.ros2.org/job/ci_windows/16708/msbuild

I've triggered a new Windows build with the changes in this PR: [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=16877)](http://ci.ros2.org/job/ci_windows/16877/)