### PR TITLE
Fix CMake warning on Windows

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.0.2)
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)
 endif()
+# Avoid warning from pybind11 on Windows
+if(POLICY CMP0054)
+  cmake_policy(SET CMP0054 NEW)
+endif()
 if(POLICY CMP0057)
   cmake_policy(SET CMP0057 NEW)  # support IN_LISTS which is required for PyBind11 2.6 and newer
 endif()


### PR DESCRIPTION
Because the minimum cmake version is set to 3.0.2, we see the following policy warning on Windows:

     CMake Warning (dev) at C:/ci/ws/install/share/cmake/pybind11/pybind11Common.cmake:127 (if):
       Policy CMP0054 is not set: Only interpret if() arguments as variables or
       keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
       details.  Use the cmake_policy command to set the policy and suppress this
       warning.

       Quoted variables like "MSVC" will no longer be dereferenced when the policy
       is set to NEW.  Since the policy is not set the OLD behavior will be used.

If we want to continue to support older versions of CMake, we should opt into the new behavior to
not break the logic in pybind11Common.cmake. Alternatively, we could increase the miminum cmake
version of this project.

For reference, here is the line that is producing the warning:

https://github.com/pybind/pybind11/blob/v2.7.1/tools/pybind11Common.cmake#L127

With the the OLD behavior, I'm pretty sure CMake it will substitute the value of the variable `MSVC` into the expression `"MSVC"`. I think we want the NEW behavior so we're comparing against the string literal "MSVC". 
