### PR TITLE
Add hash function to "dataclasses"

### DIFF
--- a/orocos_kdl/src/frameacc.hpp
+++ b/orocos_kdl/src/frameacc.hpp
@@ -34,7 +34,6 @@
 #include "frames.hpp"
 
 
-
 namespace KDL {
 
 class TwistAcc;
@@ -57,6 +56,7 @@ IMETHOD bool Equal(const TwistAcc& a,const Twist& b,double eps=epsilon);
 IMETHOD bool Equal(const VectorAcc& r1,const VectorAcc& r2,double eps=epsilon);
 IMETHOD bool Equal(const Vector& r1,const VectorAcc& r2,double eps=epsilon);
 IMETHOD bool Equal(const VectorAcc& r1,const Vector& r2,double eps=epsilon);
+
 
 class VectorAcc
 {
@@ -104,7 +104,6 @@ public:
     IMETHOD friend doubleAcc dot(const VectorAcc& lhs,const Vector& rhs);
     IMETHOD friend doubleAcc dot(const Vector& lhs,const VectorAcc& rhs);
 };
-
 
 
 class RotationAcc
@@ -160,8 +159,6 @@ public:
 };
 
 
-
-
 class FrameAcc
 {
 public:
@@ -197,12 +194,6 @@ public:
     IMETHOD TwistAcc operator * (const TwistAcc& arg) const;
     IMETHOD TwistAcc operator * (const Twist& arg) const;
 };
-
-
-
-
-
-
 
 
 //very similar to Wrench class.
@@ -257,20 +248,68 @@ public:
 
 };
 
-
-
-
-
-
-
 #ifdef KDL_INLINE
 #include "frameacc.inl"
 #endif
 
-}
+} // namespace KDL
 
+template<> struct std::hash<KDL::doubleAcc>
+{
+    std::size_t operator()(KDL::doubleAcc const& da) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, da.t);
+        KDL::hash_combine(seed, da.d);
+        KDL::hash_combine(seed, da.dd);
+        return seed;
+    }
+};
 
+template<> struct std::hash<KDL::VectorAcc>
+{
+    std::size_t operator()(KDL::VectorAcc const& va) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, va.p);
+        KDL::hash_combine(seed, va.v);
+        KDL::hash_combine(seed, va.dv);
+        return seed;
+    }
+};
 
+template<> struct std::hash<KDL::RotationAcc>
+{
+    std::size_t operator()(KDL::RotationAcc const& ra) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, ra.R);
+        KDL::hash_combine(seed, ra.w);
+        KDL::hash_combine(seed, ra.dw);
+        return seed;
+    }
+};
 
+template<> struct std::hash<KDL::FrameAcc>
+{
+    std::size_t operator()(KDL::FrameAcc const& fa) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, fa.M);
+        KDL::hash_combine(seed, fa.p);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::TwistAcc>
+{
+    std::size_t operator()(KDL::TwistAcc const& ta) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, ta.vel);
+        KDL::hash_combine(seed, ta.rot);
+        return seed;
+    }
+};
 
 #endif

--- a/orocos_kdl/src/frames.hpp
+++ b/orocos_kdl/src/frames.hpp
@@ -127,11 +127,13 @@
 
 #include "utilities/kdl-config.h"
 #include "utilities/utility.h"
+#include "utilities/hash_combine.h"
+
+#include <functional>
 
 /////////////////////////////////////////////////////////////
 
 namespace KDL {
-
 
 
 class Vector;
@@ -711,6 +713,7 @@ public:
      inline friend bool operator!=(const Frame& a,const Frame& b);
 };
 
+
 /**
  * \brief represents both translational and rotational velocities.
  *
@@ -788,8 +791,8 @@ public:
 // = Friends
     friend class Rotation;
     friend class Frame;
-
 };
+
 
 /**
  * 	\brief represents both translational and rotational acceleration.
@@ -950,8 +953,6 @@ public:
 
     friend class Rotation;
     friend class Frame;
-
-
 };
 
 
@@ -1090,6 +1091,7 @@ public:
      //! different.  It compares whether the 2 arguments are equal in an eps-interval
      inline friend bool Equal(const Rotation2& a,const Rotation2& b,double eps);
 };
+
 
 //! A 2D frame class, for further documentation see the Frames class
 //! for methods with unchanged semantics.
@@ -1257,5 +1259,96 @@ IMETHOD Wrench addDelta(const Wrench& a,const Wrench&da,double dt=1);
 
 }
 
+template<> struct std::hash<KDL::Vector>
+{
+    std::size_t operator()(KDL::Vector const& v) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, v.x());
+        KDL::hash_combine(seed, v.y());
+        KDL::hash_combine(seed, v.z());
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::Rotation>
+{
+    std::size_t operator()(KDL::Rotation const& r) const noexcept
+    {
+        size_t seed = 0;
+        double x, y, z, w;
+        r.GetQuaternion(x, y, z, w);
+        KDL::hash_combine(seed, x);
+        KDL::hash_combine(seed, y);
+        KDL::hash_combine(seed, z);
+        KDL::hash_combine(seed, w);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::Frame>
+{
+    std::size_t operator()(KDL::Frame const& f) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, f.p);
+        KDL::hash_combine(seed, f.M);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::Wrench>
+{
+    std::size_t operator()(KDL::Wrench const& w) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, w.force);
+        KDL::hash_combine(seed, w.torque);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::Twist>
+{
+    std::size_t operator()(KDL::Twist const& t) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, t.vel);
+        KDL::hash_combine(seed, t.rot);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::Vector2>
+{
+    std::size_t operator()(KDL::Vector2 const& v) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, v.x());
+        KDL::hash_combine(seed, v.y());
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::Rotation2>
+{
+    std::size_t operator()(KDL::Rotation2 const& r) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, r.GetRot());
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::Frame2>
+{
+    std::size_t operator()(KDL::Frame2 const& f) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, f.p);
+        KDL::hash_combine(seed, f.M);
+        return seed;
+    }
+};
 
 #endif

--- a/orocos_kdl/src/framevel.hpp
+++ b/orocos_kdl/src/framevel.hpp
@@ -30,7 +30,6 @@
 #include "frames.hpp"
 
 
-
 namespace KDL {
 
 typedef Rall1d<double> doubleVel;
@@ -80,6 +79,7 @@ IMETHOD bool Equal(const FrameVel& r1,const Frame& r2,double eps=epsilon);
 IMETHOD bool Equal(const TwistVel& a,const TwistVel& b,double eps=epsilon);
 IMETHOD bool Equal(const Twist& a,const TwistVel& b,double eps=epsilon);
 IMETHOD bool Equal(const TwistVel& a,const Twist& b,double eps=epsilon);
+
 
 class VectorVel
 // = TITLE
@@ -141,7 +141,6 @@ public:
     IMETHOD friend doubleVel dot(const VectorVel& lhs,const Vector& rhs);
     IMETHOD friend doubleVel dot(const Vector& lhs,const VectorVel& rhs);
 };
-
 
 
 class RotationVel
@@ -207,8 +206,6 @@ public:
 };
 
 
-
-
 class FrameVel
 // = TITLE
 //     An FrameVel is a Frame and its first derivative, a Twist vector
@@ -266,9 +263,6 @@ public:
     IMETHOD TwistVel operator * (const TwistVel& arg) const;
     IMETHOD TwistVel operator * (const Twist& arg) const;
 };
-
-
-
 
 
 //very similar to Wrench class.
@@ -416,10 +410,61 @@ IMETHOD void posrandom(FrameVel& F) {
 #include "framevel.inl"
 #endif
 
-} // namespace
+} // namespace KDL
+
+template<> struct std::hash<KDL::doubleVel>
+{
+    std::size_t operator()(KDL::doubleVel const& dv) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, dv.value());
+        KDL::hash_combine(seed, dv.deriv());
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::VectorVel>
+{
+    std::size_t operator()(KDL::VectorVel const& vv) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, vv.p);
+        KDL::hash_combine(seed, vv.v);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::RotationVel>
+{
+    std::size_t operator()(KDL::RotationVel const& rv) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, rv.R);
+        KDL::hash_combine(seed, rv.w);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::FrameVel>
+{
+    std::size_t operator()(KDL::FrameVel const& fv) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, fv.M);
+        KDL::hash_combine(seed, fv.p);
+        return seed;
+    }
+};
+
+template<> struct std::hash<KDL::TwistVel>
+{
+    std::size_t operator()(KDL::TwistVel const& tv) const noexcept
+    {
+        size_t seed = 0;
+        KDL::hash_combine(seed, tv.vel);
+        KDL::hash_combine(seed, tv.rot);
+        return seed;
+    }
+};
 
 #endif
-
-
-
-

--- a/orocos_kdl/src/utilities/hash_combine.h
+++ b/orocos_kdl/src/utilities/hash_combine.h
@@ -1,0 +1,26 @@
+#ifndef KDL_HASH_COMBINE_H_
+#define KDL_HASH_COMBINE_H_
+
+#include <functional>
+
+namespace KDL
+{
+
+/**
+ * @brief Combine hash of object \p v to the \p seed
+ * @param seed Seed to append the hash of \p v
+ * @param v Object of which the hash should be appended to the seed
+ *
+ * Inspired by:
+ * @link https://github.com/boostorg/multiprecision/blob/boost-1.79.0/include/boost/multiprecision/detail/hash.hpp#L35-L41
+ */
+template <class T>
+inline void hash_combine(std::size_t& seed, const T& v)
+{
+  std::hash<T> hasher;
+  seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+}
+
+#endif

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -36,8 +36,8 @@ void FramesTest::TestVector() {
 	Vector   v2(0,0,0);
 	TestVector2(v2);
 
-    CPPUNIT_ASSERT_EQUAL(std::hash<Vector>{}(v), static_cast<size_t>(3450679443808348711));
-    CPPUNIT_ASSERT_EQUAL(std::hash<Vector>{}(v2), static_cast<size_t>(11093822414574));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Vector>{}(v), static_cast<size_t>(3450679443808348711u));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Vector>{}(v2), static_cast<size_t>(11093822414574u));
 	
 	Vector nu(0,0,0);
 	CPPUNIT_ASSERT_EQUAL(nu.Norm(),0.0);
@@ -80,8 +80,8 @@ void FramesTest::TestTwist() {
 	Twist    t3(Vector(0,-9,-3),Vector(1,-2,-4));
 	TestTwist2(t3);	
 
-    CPPUNIT_ASSERT_EQUAL(std::hash<Twist>{}(t3), static_cast<size_t>(3373832976806748309));
-    CPPUNIT_ASSERT_EQUAL(std::hash<Twist>{}(t2), static_cast<size_t>(730713428471863));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Twist>{}(t3), static_cast<size_t>(3373832976806748309u));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Twist>{}(t2), static_cast<size_t>(730713428471863u));
 }
 
 void FramesTest::TestWrench2(Wrench& w) {
@@ -109,8 +109,8 @@ void FramesTest::TestWrench() {
 	Wrench   w3(Vector(2,1,4),Vector(5,3,1));
     TestWrench2(w3);
 
-    CPPUNIT_ASSERT_EQUAL(std::hash<Wrench>{}(w3), static_cast<size_t>(13897938943539516747));
-    CPPUNIT_ASSERT_EQUAL(std::hash<Wrench>{}(w2), static_cast<size_t>(730713428471863));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Wrench>{}(w3), static_cast<size_t>(13897938943539516747u));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Wrench>{}(w2), static_cast<size_t>(730713428471863u));
 }
 
 void FramesTest::TestRotation2(const Vector& v,double a,double b,double c) {
@@ -420,8 +420,8 @@ void FramesTest::TestRotation() {
 
 	TestOneRotation("rot([0.707107, 0, 0.707107", KDL::Rotation::RPY(-2.9811968953315162, -atan(1)*2, -0.1603957582582825), 180*deg2rad, Vector(0.707107,0,0.707107) );
 
-    CPPUNIT_ASSERT_EQUAL(std::hash<Rotation>{}(Rotation::Quaternion(1, 0, 0, 0)), static_cast<size_t>(5526237894416316219));
-    CPPUNIT_ASSERT_EQUAL(std::hash<Rotation>{}(Rotation()), static_cast<size_t>(8386870752212395617));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Rotation>{}(Rotation::Quaternion(1, 0, 0, 0)), static_cast<size_t>(5526237894416316219u));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Rotation>{}(Rotation()), static_cast<size_t>(8386870752212395617u));
 }
 
 void FramesTest::TestGetRotAngle() {
@@ -666,8 +666,8 @@ void FramesTest::TestFrame() {
     CPPUNIT_ASSERT(Equal(Frame::DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989));
     CPPUNIT_ASSERT(Equal(Frame().DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989)); // Only for testing purposes, shouldn't use static function of instances
 
-    CPPUNIT_ASSERT_EQUAL(std::hash<Frame>{}(F), static_cast<size_t>(6112004106257185417));
-    CPPUNIT_ASSERT_EQUAL(std::hash<Frame>{}(Frame()), static_cast<size_t>(8387572672274540708));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Frame>{}(F), static_cast<size_t>(6112004106257185417u));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Frame>{}(Frame()), static_cast<size_t>(8387572672274540708u));
 }
 
 JntArray CreateRandomJntArray(int size)

--- a/orocos_kdl/tests/framestest.cpp
+++ b/orocos_kdl/tests/framestest.cpp
@@ -21,6 +21,7 @@ void FramesTest::TestVector2(Vector& v) {
 	CPPUNIT_ASSERT_EQUAL(v+v+v-2*v,v);
 	v2=v;
 	CPPUNIT_ASSERT_EQUAL(v,v2);
+    CPPUNIT_ASSERT_EQUAL(std::hash<Vector>{}(v), std::hash<Vector>{}(v2));
 	v2+=v;
 	CPPUNIT_ASSERT_EQUAL(2*v,v2);
 	v2-=v;
@@ -34,6 +35,9 @@ void FramesTest::TestVector() {
 	TestVector2(v);
 	Vector   v2(0,0,0);
 	TestVector2(v2);
+
+    CPPUNIT_ASSERT_EQUAL(std::hash<Vector>{}(v), static_cast<size_t>(3450679443808348711));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Vector>{}(v2), static_cast<size_t>(11093822414574));
 	
 	Vector nu(0,0,0);
 	CPPUNIT_ASSERT_EQUAL(nu.Norm(),0.0);
@@ -59,11 +63,12 @@ void FramesTest::TestTwist2(Twist& t) {
 	CPPUNIT_ASSERT_EQUAL(t+t+t-2*t,t);
 	t2=t;
 	CPPUNIT_ASSERT_EQUAL(t,t2);
+    CPPUNIT_ASSERT_EQUAL(std::hash<Twist>{}(t), std::hash<Twist>{}(t2));
 	t2+=t;
 	CPPUNIT_ASSERT_EQUAL(2*t,t2);
 	t2-=t;
 	CPPUNIT_ASSERT_EQUAL(t,t2);
-	t.ReverseSign();
+    t2.ReverseSign();
 	CPPUNIT_ASSERT_EQUAL(t,-t2);
 }
 
@@ -74,6 +79,9 @@ void FramesTest::TestTwist() {
 	TestTwist2(t2);	
 	Twist    t3(Vector(0,-9,-3),Vector(1,-2,-4));
 	TestTwist2(t3);	
+
+    CPPUNIT_ASSERT_EQUAL(std::hash<Twist>{}(t3), static_cast<size_t>(3373832976806748309));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Twist>{}(t2), static_cast<size_t>(730713428471863));
 }
 
 void FramesTest::TestWrench2(Wrench& w) {
@@ -84,11 +92,12 @@ void FramesTest::TestWrench2(Wrench& w) {
 	CPPUNIT_ASSERT_EQUAL(w+w+w-2*w,w);
 	w2=w;
 	CPPUNIT_ASSERT_EQUAL(w,w2);
+    CPPUNIT_ASSERT_EQUAL(std::hash<Wrench>{}(w), std::hash<Wrench>{}(w2));
 	w2+=w;
 	CPPUNIT_ASSERT_EQUAL(2*w,w2);
 	w2-=w;
 	CPPUNIT_ASSERT_EQUAL(w,w2);
-	w.ReverseSign();
+    w2.ReverseSign();
 	CPPUNIT_ASSERT_EQUAL(w,-w2);
 }
 
@@ -98,7 +107,10 @@ void FramesTest::TestWrench() {
 	Wrench   w2(Vector(0,0,0),Vector(0,0,0));
 	TestWrench2(w2);
 	Wrench   w3(Vector(2,1,4),Vector(5,3,1));
-	TestWrench2(w3);		
+    TestWrench2(w3);
+
+    CPPUNIT_ASSERT_EQUAL(std::hash<Wrench>{}(w3), static_cast<size_t>(13897938943539516747));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Wrench>{}(w2), static_cast<size_t>(730713428471863));
 }
 
 void FramesTest::TestRotation2(const Vector& v,double a,double b,double c) {
@@ -122,6 +134,7 @@ void FramesTest::TestRotation2(const Vector& v,double a,double b,double c) {
 	CPPUNIT_ASSERT_DOUBLES_EQUAL(dot(R.UnitY(),R.UnitZ()),0.0,epsilon);
 	R2=R;
 	CPPUNIT_ASSERT_EQUAL(R,R2);
+    CPPUNIT_ASSERT_EQUAL(std::hash<Rotation>{}(R), std::hash<Rotation>{}(R2));
 	CPPUNIT_ASSERT_DOUBLES_EQUAL((R*v).Norm(),v.Norm(),epsilon);
 	CPPUNIT_ASSERT_EQUAL(R.Inverse(R*v),v);
 	CPPUNIT_ASSERT_EQUAL(R.Inverse(R*t),t);
@@ -406,6 +419,9 @@ void FramesTest::TestRotation() {
 	TestOneRotation("rot([-1,-1,-1],-180)", KDL::Rotation::Rot(KDL::Vector(-1,-1,-1),-180*deg2rad), 180*deg2rad, Vector(1,1,1)/sqrt(3.0));
 
 	TestOneRotation("rot([0.707107, 0, 0.707107", KDL::Rotation::RPY(-2.9811968953315162, -atan(1)*2, -0.1603957582582825), 180*deg2rad, Vector(0.707107,0,0.707107) );
+
+    CPPUNIT_ASSERT_EQUAL(std::hash<Rotation>{}(Rotation::Quaternion(1, 0, 0, 0)), static_cast<size_t>(5526237894416316219));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Rotation>{}(Rotation()), static_cast<size_t>(8386870752212395617));
 }
 
 void FramesTest::TestGetRotAngle() {
@@ -619,6 +635,7 @@ void FramesTest::TestFrame() {
 	F = Frame(Rotation::EulerZYX(10*deg2rad,20*deg2rad,-10*deg2rad),Vector(4,-2,1));
 	F2=F   ;
 	CPPUNIT_ASSERT_EQUAL(F,F2);
+    CPPUNIT_ASSERT_EQUAL(std::hash<Frame>{}(F), std::hash<Frame>{}(F2));
 	CPPUNIT_ASSERT_EQUAL(F.Inverse(F*v),v);
 	CPPUNIT_ASSERT_EQUAL(F.Inverse(F*t),t);
 	CPPUNIT_ASSERT_EQUAL(F.Inverse(F*w),w);
@@ -648,6 +665,9 @@ void FramesTest::TestFrame() {
                                  Vector(0, -0.36, 0));
     CPPUNIT_ASSERT(Equal(Frame::DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989));
     CPPUNIT_ASSERT(Equal(Frame().DH_Craig1989(0.0, M_PI_2, 0.36, 0.0), F_DH_Craig1989)); // Only for testing purposes, shouldn't use static function of instances
+
+    CPPUNIT_ASSERT_EQUAL(std::hash<Frame>{}(F), static_cast<size_t>(6112004106257185417));
+    CPPUNIT_ASSERT_EQUAL(std::hash<Frame>{}(Frame()), static_cast<size_t>(8387572672274540708));
 }
 
 JntArray CreateRandomJntArray(int size)

--- a/python_orocos_kdl/PyKDL/frames.cpp
+++ b/python_orocos_kdl/PyKDL/frames.cpp
@@ -77,6 +77,7 @@ void init_frames(py::module &m)
     vector.def(py::self * py::self);
     vector.def(py::self == py::self);
     vector.def(py::self != py::self);
+    vector.def(py::hash(py::self));
     vector.def("__neg__", [](const Vector &a)
     {
         return operator-(a);
@@ -163,6 +164,7 @@ void init_frames(py::module &m)
     wrench.def(py::self - py::self);
     wrench.def(py::self == py::self);
     wrench.def(py::self != py::self);
+    wrench.def(py::hash(py::self));
     wrench.def("__neg__", [](const Wrench &w)
     {
         return operator-(w);
@@ -237,6 +239,7 @@ void init_frames(py::module &m)
     twist.def(py::self - py::self);
     twist.def(py::self == py::self);
     twist.def(py::self != py::self);
+    twist.def(py::hash(py::self));
     twist.def("__neg__", [](const Twist &a)
     {
         return operator-(a);
@@ -369,6 +372,7 @@ void init_frames(py::module &m)
     rotation.def(py::self == py::self);
     rotation.def(py::self != py::self);
     rotation.def(py::self * py::self);
+    rotation.def(py::hash(py::self));
     rotation.def(py::pickle(
             [](const Rotation &rot)
             { // __getstate__
@@ -450,6 +454,7 @@ void init_frames(py::module &m)
     frame.def(py::self * py::self);
     frame.def(py::self == py::self);
     frame.def(py::self != py::self);
+    frame.def(py::hash(py::self));
     frame.def(py::pickle(
             [](const Frame &frm)
             { // __getstate__

--- a/python_orocos_kdl/PyKDL/framevel.cpp
+++ b/python_orocos_kdl/PyKDL/framevel.cpp
@@ -62,7 +62,7 @@ void init_framevel(pybind11::module &m)
 
     double_vel.def(py::self == py::self);
     double_vel.def(py::self != py::self);
-
+    double_vel.def(py::hash(py::self));
     double_vel.def("__neg__", [](const doubleVel &a)
     {
         return operator-(a);
@@ -132,6 +132,7 @@ void init_framevel(pybind11::module &m)
     vector_vel.def(Vector() != py::self);
     vector_vel.def(py::self == Vector());
     vector_vel.def(py::self != Vector());
+    vector_vel.def(py::hash(py::self));
     vector_vel.def("__neg__", [](const VectorVel &a)
     {
         return operator-(a);
@@ -217,6 +218,7 @@ void init_framevel(pybind11::module &m)
     twist_vel.def(Twist() != py::self);
     twist_vel.def(py::self == Twist());
     twist_vel.def(py::self != Twist());
+    twist_vel.def(py::hash(py::self));
     twist_vel.def("__neg__", [](const TwistVel &a)
     {
         return operator-(a);
@@ -305,6 +307,7 @@ void init_framevel(pybind11::module &m)
     rotation_vel.def(Rotation() != py::self);
     rotation_vel.def(py::self == Rotation());
     rotation_vel.def(py::self != Rotation());
+    rotation_vel.def(py::hash(py::self));
     rotation_vel.def(py::pickle(
             [](const RotationVel &rv)
             { // __getstate__
@@ -378,6 +381,7 @@ void init_framevel(pybind11::module &m)
     frame_vel.def(Frame() != py::self);
     frame_vel.def(py::self == Frame());
     frame_vel.def(py::self != Frame());
+    frame_vel.def(py::hash(py::self));
     frame_vel.def(py::pickle(
             [](const FrameVel &fv)
             { // __getstate__

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -115,14 +115,14 @@ class FramesTestFunctions(unittest.TestCase):
         self.testTwistImpl(t)
 
         # Equality
-        t = Twist(Vector(1, 2, 3), Vector(1, 2, 3))
+        t = Twist(Vector(0, -9, -3), Vector(1, -2, -4))
         self.assertFalse(t == -t)  # Doesn't work for zero twist
         self.assertFalse(Equal(t, -t))  # Doesn't work for zero twist
         self.assertTrue(t != -t)  # Doesn't work for zero twist
         self.assertTrue(not Equal(t, -t))  # Doesn't work for zero twist
 
         # Hash
-        self.assertEqual(hash(t), 551895977443887016)
+        self.assertEqual(hash(t), 3373832976806748309)
         self.assertEqual(hash(Twist()), 730713428471863)
 
         # Members

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -200,7 +200,7 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertTrue(not Equal(w, -w))  # Doesn't work for zero wrench
 
         # Hash
-        self.assertEqual(hash(w), 551895977443887016)
+        self.assertEqual(hash(w), hash(13897938943539516747))  # 551895977443887016
         self.assertEqual(hash(Wrench()), 730713428471863)
 
         # Members

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -194,7 +194,6 @@ class FramesTestFunctions(unittest.TestCase):
         self.testWrenchImpl(w)
 
         # Equality
-        w = Wrench(Vector(1, 2, 3), Vector(1, 2, 3))
         self.assertFalse(w == -w)  # Doesn't work for zero wrench
         self.assertFalse(Equal(w, -w))  # Doesn't work for zero wrench
         self.assertTrue(w != -w)  # Doesn't work for zero wrench

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -200,7 +200,7 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertTrue(not Equal(w, -w))  # Doesn't work for zero wrench
 
         # Hash
-        self.assertEqual(hash(w), 13897938943539516747)
+        self.assertEqual(hash(w), 551895977443887016)
         self.assertEqual(hash(Wrench()), 730713428471863)
 
         # Members

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -42,6 +42,10 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertTrue(v != -v)  # Doesn't work for zero vector
         self.assertTrue(not Equal(v, -v))  # Doesn't work for zero vector
 
+        # Hash
+        self.assertEqual(hash(v), 3450679443808348711)
+        self.assertEqual(hash(Vector()), 11093822414574)
+
         # Test member get and set functions
         self.assertEqual(v.x(), 3)
         v.x(1)
@@ -89,6 +93,7 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertEqual(v+v+v-2*v, v)
         v2 = Vector(v)
         self.assertEqual(v, v2)
+        self.assertEqual(hash(v), hash(v2))
         v2 += v
         self.assertEqual(2*v, v2)
         v2 -= v
@@ -115,6 +120,10 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertFalse(Equal(t, -t))  # Doesn't work for zero twist
         self.assertTrue(t != -t)  # Doesn't work for zero twist
         self.assertTrue(not Equal(t, -t))  # Doesn't work for zero twist
+
+        # Hash
+        self.assertEqual(hash(t), 551895977443887016)
+        self.assertEqual(hash(Twist()), 730713428471863)
 
         # Members
         v1 = Vector(1, 2, 3)
@@ -158,6 +167,7 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertEqual(t+t+t-2*t, t)
         t2 = Twist(t)
         self.assertEqual(t, t2)
+        self.assertEqual(hash(t), hash(t2))
         t2 += t
         self.assertEqual(2*t, t2)
         t2 -= t
@@ -189,6 +199,10 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertFalse(Equal(w, -w))  # Doesn't work for zero wrench
         self.assertTrue(w != -w)  # Doesn't work for zero wrench
         self.assertTrue(not Equal(w, -w))  # Doesn't work for zero wrench
+
+        # Hash
+        self.assertEqual(hash(w), 551895977443887016)
+        self.assertEqual(hash(Wrench()), 730713428471863)
 
         # Members
         v1 = Vector(1, 2, 3)
@@ -228,6 +242,7 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertEqual(w+w+w-2*w, w)
         w2 = Wrench(w)
         self.assertEqual(w, w2)
+        self.assertEqual(hash(w), hash(w2))
         w2 += w
         self.assertEqual(2*w, w2)
         w2 -= w
@@ -245,6 +260,10 @@ class FramesTestFunctions(unittest.TestCase):
         self.testRotationImpl(Rotation.RPY(radians(10), radians(20), radians(30)), Vector())
         self.testRotationImpl(Rotation(), Vector(3, 4, 5))
         self.testRotationImpl(Rotation(), Vector())
+
+        # Hash
+        self.assertEqual(hash(Rotation.Quaternion(1, 0, 0, 0)), 5526237894416316219)
+        self.assertEqual(hash(Rotation()), 8386870752212395617)
 
         r = Rotation(*range(1, 10))
 
@@ -290,6 +309,7 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertAlmostEqual(dot(r.UnitY(), r.UnitZ()), 0.0, 15)
         r2 = Rotation(r)
         self.assertEqual(r, r2)
+        self.assertEqual(hash(r), hash(r2))
         self.assertAlmostEqual((r*v).Norm(), v.Norm(), 14)
         self.assertEqual(r.Inverse(r*v), v)
         self.assertEqual(r.Inverse(r*t), t)
@@ -339,6 +359,11 @@ class FramesTestFunctions(unittest.TestCase):
         # Equality
         f2 = Frame(f)
         self.assertEqual(f, f2)
+        self.assertEqual(hash(f), hash(f2))
+
+        # Hash
+        self.assertEqual(hash(f), 6112004106257185417)
+        self.assertEqual(hash(Frame()), 8387572672274540708)
 
         # Members
         self.assertEqual(f.M, r)

--- a/python_orocos_kdl/tests/framestest.py
+++ b/python_orocos_kdl/tests/framestest.py
@@ -200,7 +200,7 @@ class FramesTestFunctions(unittest.TestCase):
         self.assertTrue(not Equal(w, -w))  # Doesn't work for zero wrench
 
         # Hash
-        self.assertEqual(hash(w), 551895977443887016)
+        self.assertEqual(hash(w), 13897938943539516747)
         self.assertEqual(hash(Wrench()), 730713428471863)
 
         # Members

--- a/python_orocos_kdl/tests/frameveltest.py
+++ b/python_orocos_kdl/tests/frameveltest.py
@@ -32,6 +32,7 @@ class FrameVelTestFunctions(unittest.TestCase):
     def testdoubleVel(self):
         d = doubleVel()
         self.assertEqual(doubleVel(d), d)
+        self.assertEqual(hash(d), hash(doubleVel(d)))
         self.assertEqual(d.t, 0)
         self.assertEqual(d.grad, 0)
         self.assertEqual(d.value(), 0)
@@ -65,6 +66,10 @@ class FrameVelTestFunctions(unittest.TestCase):
         self.assertTrue(v != -v)  # Doesn't work for zero VectorVel
         self.assertTrue(not Equal(v, -v))  # Doesn't work for zero VectorVel
 
+        # Hash
+        self.assertEqual(hash(v), 2049006275376269995)
+        self.assertEqual(hash(VectorVel()), 730713428471863)
+
         v = VectorVel(v1)
         self.assertEqual(v, v1)
         self.assertEqual(v1, v)
@@ -88,6 +93,7 @@ class FrameVelTestFunctions(unittest.TestCase):
         self.assertEqual(v+v+v-2*v, v)
         v2 = VectorVel(v)
         self.assertEqual(v, v2)
+        self.assertEqual(hash(v), hash(v2))
         v2 += v
         self.assertEqual(2*v, v2)
         v2 -= v
@@ -135,6 +141,10 @@ class FrameVelTestFunctions(unittest.TestCase):
         self.assertEqual(t, t2)
         self.assertEqual(t2, t)
 
+        # Hash
+        self.assertEqual(hash(t), 141466195908239803)
+        self.assertEqual(hash(TwistVel()), 48409940491385244)
+
         # Zero
         SetToZero(t)
         self.assertEqual(t, TwistVel())
@@ -146,6 +156,7 @@ class FrameVelTestFunctions(unittest.TestCase):
         self.assertEqual(t+t+t-2*t, t)
         t2 = TwistVel(t)
         self.assertEqual(t, t2)
+        self.assertEqual(hash(t), hash(t2))
         t2 += t
         self.assertEqual(2*t, t2)
         t2 -= t
@@ -180,9 +191,14 @@ class FrameVelTestFunctions(unittest.TestCase):
         self.assertEqual(RotationVel(rot), rot)
         self.assertEqual(rot, RotationVel(rot))
 
+        # Hash
+        self.assertEqual(hash(r), 6921222406909663069)
+        self.assertEqual(hash(RotationVel()), 4775665235973850935)
+
     def testRotationVelImpl(self, r, v, vt):
         r2 = RotationVel(r)
         self.assertEqual(r, r2)
+        self.assertEqual(hash(r), hash(r2))
         self.assertEqual((r*v).Norm(), v.Norm())
         self.assertEqual(r.Inverse(r*v), v)
         self.assertEqual(r*r.Inverse(v), v)
@@ -231,9 +247,14 @@ class FrameVelTestFunctions(unittest.TestCase):
         self.assertEqual(f, fr)
         self.assertEqual(fr, f)
 
+        # Hash
+        self.assertEqual(hash(fr), 6112004106257185417)
+        self.assertEqual(hash(FrameVel()), 35564562501293795)
+
     def testFrameVelImpl(self, f, v, vt):
         f2 = FrameVel(f)
         self.assertEqual(f, f2)
+        self.assertEqual(hash(f), hash(f2))
         self.assertEqual(f.Inverse(f*v), v)
         self.assertEqual(f.Inverse(f*vt), vt)
         self.assertEqual(f*f.Inverse(v), v)

--- a/python_orocos_kdl/tests/frameveltest.py
+++ b/python_orocos_kdl/tests/frameveltest.py
@@ -67,7 +67,11 @@ class FrameVelTestFunctions(unittest.TestCase):
         self.assertTrue(not Equal(v, -v))  # Doesn't work for zero VectorVel
 
         # Hash
-        self.assertEqual(hash(v), 2049006275376269995)
+        if sys.version_info < (3, 0):
+            self.assertEqual(hash(v), -4868522752264811866)
+        else:
+            self.assertEqual(hash(v), 2049006275376269995)
+
         self.assertEqual(hash(VectorVel()), 730713428471863)
 
         v = VectorVel(v1)
@@ -249,7 +253,10 @@ class FrameVelTestFunctions(unittest.TestCase):
 
         # Hash
         self.assertEqual(hash(fr), 6112004106257185417)
-        self.assertEqual(hash(FrameVel()), 35564562501293795)
+        if sys.version_info < (3, 0):
+            self.assertEqual(hash(FrameVel()), -2270278446712400164)
+        else:
+            self.assertEqual(hash(FrameVel()), 35564562501293795)
 
     def testFrameVelImpl(self, f, v, vt):
         f2 = FrameVel(f)


### PR DESCRIPTION
`std::hash` is only available from c++11. Do we want to to check for this (`#if (__cplusplus > 201103L)`? Or can we assume that all users have minimal c++11?