### PR TITLE
do not read outside array

### DIFF
--- a/orocos_kdl/src/chainhdsolver_vereshchagin.cpp
+++ b/orocos_kdl/src/chainhdsolver_vereshchagin.cpp
@@ -138,7 +138,7 @@ void ChainHdSolver_Vereshchagin::initial_upwards_sweep(const JntArray &q, const 
 void ChainHdSolver_Vereshchagin::downwards_sweep(const Jacobian& alfa, const JntArray &ff_torques)
 {
     int j = nj - 1;
-    for (int i = ns; i >= 0; i--)
+    for (int i = ns-1; i >= 0; i--)
     {
         //Get a handle for the segment we are working on.
         segment_info& s = results[i];
@@ -150,7 +150,7 @@ void ChainHdSolver_Vereshchagin::downwards_sweep(const Jacobian& alfa, const Jnt
         //M is the (unit) acceleration energy already generated at link i
         //G is the (unit) magnitude of the constraint forces at link i
         //E are the (unit) constraint forces due to the constraints
-        if (i == (int)ns)
+        if (i == (int)ns-1)
         {
             s.P_tilde = s.H;
             s.R_tilde = s.U;

--- a/orocos_kdl/src/chainhdsolver_vereshchagin.cpp
+++ b/orocos_kdl/src/chainhdsolver_vereshchagin.cpp
@@ -150,7 +150,7 @@ void ChainHdSolver_Vereshchagin::downwards_sweep(const Jacobian& alfa, const Jnt
         //M is the (unit) acceleration energy already generated at link i
         //G is the (unit) magnitude of the constraint forces at link i
         //E are the (unit) constraint forces due to the constraints
-        if (i == (int)ns-1)
+        if (i == static_cast<int>(ns)-1)
         {
             s.P_tilde = s.H;
             s.R_tilde = s.U;


### PR DESCRIPTION
An error in the Vereshchagin hybrid dynamics solver causes NaNs to be propagated through the data. The cause is a faulty loop in the downwards sweep which starts by reading segment ns, where ns is the number of segments in the chain. However the chain only contains segments 0 through to ns-1. 

Small fix was implemented. Ideally unit tests could prevent this in the future.