### PR TITLE
Set correct rpath for python module

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -43,6 +43,40 @@ if(catkin_FOUND)
   set(PYTHON_SITE_PACKAGES_INSTALL_DIR "${PYTHON_INSTALL_DIR}")
 endif()
 
+# OROCOSKDL_ENABLE_RPATH
+IF(NOT MSVC)
+    #add the option to disable RPATH
+    OPTION(OROCOSKDL_ENABLE_RPATH "Enable RPATH during installation" TRUE)
+    MARK_AS_ADVANCED(OROCOSKDL_ENABLE_RPATH)
+ENDIF(NOT MSVC)
+
+IF(OROCOSKDL_ENABLE_RPATH)
+    #Configure RPATH
+    SET(CMAKE_MACOSX_RPATH TRUE) #enable RPATH on OSX. This also suppress warnings on CMake >= 3.0
+    # when building, don't use the install RPATH already
+    # (but later on when installing)
+    SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+    #build directory by default is built with RPATH
+    SET(CMAKE_SKIP_BUILD_RPATH  FALSE)
+
+    #This is relative RPATH for libraries built in the same project
+    #I assume that the directory is
+    # - install_dir/something for binaries
+    # - install_dir/lib for libraries
+    LIST(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
+    IF("${isSystemDir}" STREQUAL "-1")
+        FILE(RELATIVE_PATH _rel_path "${PYTHON_SITE_PACKAGES_INSTALL_DIR}" "${CMAKE_INSTALL_PREFIX}/lib" )
+        IF (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            SET(CMAKE_INSTALL_RPATH "@loader_path/${_rel_path}")
+        ELSE()
+            SET(CMAKE_INSTALL_RPATH "\$ORIGIN/${_rel_path}")
+        ENDIF()
+    ENDIF("${isSystemDir}" STREQUAL "-1")
+    # add the automatically determined parts of the RPATH
+    # which point to directories outside the build tree to the install RPATH
+    SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE) #very important!
+ENDIF()
+
 # Build the module
 if(WIN32)
   set(PYTHON_MODULE_EXTENSION ".pyd")


### PR DESCRIPTION
This package is currently breaking ROS2 builds on MacOS. Can this be merged into master so source builds succeed?

  
Since newer versions of OSX you cannot rely on the DYLD_LIBRARY_PATH anymore
  to find depending libraries, the rpath is the only way to get this working

Signed-off-by: Ruben Smits <ruben@intermodalics.eu>