### PR TITLE
(PyKDL) let catkin export CMake and PkgConfig files

### DIFF
--- a/python_orocos_kdl/CMakeLists.txt
+++ b/python_orocos_kdl/CMakeLists.txt
@@ -35,10 +35,7 @@ set(LIBRARY_NAME "PyKDL")
 # catkin-specific configuration (optional)
 find_package(catkin QUIET)
 if(catkin_FOUND)
-  catkin_package(
-    SKIP_CMAKE_CONFIG_GENERATION
-    SKIP_PKG_CONFIG_GENERATION
-  )
+  catkin_package()
   set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${PYTHON_INSTALL_DIR})
   set(PYTHON_SITE_PACKAGES_INSTALL_DIR "${PYTHON_INSTALL_DIR}")
 endif()


### PR DESCRIPTION
@meyerj You added this in 7e1f40d4d043811ea12ac1f620dae431d1338df1. But this prevents to find the package in a CMakeLists.

Is there any reason why you did add these flags?