### PR TITLE
Rename variables with reserved names

### DIFF
--- a/orocos_kdl/src/chainiksolverpos_lma.cpp
+++ b/orocos_kdl/src/chainiksolverpos_lma.cpp
@@ -49,7 +49,7 @@ inline void Twist_to_Eigen(const KDL::Twist& t,Eigen::MatrixBase<Derived>& e) {
 
 ChainIkSolverPos_LMA::ChainIkSolverPos_LMA(
 		const KDL::Chain& _chain,
-		const Eigen::Matrix<double,6,1>& _L,
+		const Eigen::Matrix<double,6,1>& _l,
 		double _eps,
 		int _maxiter,
 		double _eps_joints
@@ -68,7 +68,7 @@ ChainIkSolverPos_LMA::ChainIkSolverPos_LMA(
 	maxiter(_maxiter),
 	eps(_eps),
 	eps_joints(_eps_joints),
-	L(_L.cast<ScalarType>()),
+	L(_l.cast<ScalarType>()),
 	T_base_jointroot(nj),
 	T_base_jointtip(nj),
 	q(nj),

--- a/orocos_kdl/src/chainiksolverpos_lma.hpp
+++ b/orocos_kdl/src/chainiksolverpos_lma.hpp
@@ -83,7 +83,7 @@ public:
 	 * \f$ E = \Delta \mathbf{x}^T \mathbf{L} \mathbf{L}^T \Delta \mathbf{x} \f$, with \f$\mathbf{L}\f$ a diagonal matrix.
 	 *
 	 * \param _chain specifies the kinematic chain.
-	 * \param _L specifies the "square root" of the weight (diagonal) matrix in task space. This diagonal matrix is specified as a vector.
+	 * \param _l specifies the "square root" of the weight (diagonal) matrix in task space. This diagonal matrix is specified as a vector.
 	 * \param _eps specifies the desired accuracy in task space; <B>after</B> weighing with
 	 *        the weight matrix, it is applied on \f$E\f$.
 	 * \param _maxiter specifies the maximum number of iterations.
@@ -94,7 +94,7 @@ public:
      */
     ChainIkSolverPos_LMA(
     		const KDL::Chain& _chain,
-    		const Eigen::Matrix<double,6,1>& _L,
+		const Eigen::Matrix<double,6,1>& _l,
     		double _eps=1E-5,
     		int _maxiter=500,
     		double _eps_joints=1E-15


### PR DESCRIPTION
From the [GNU libc manual](https://www.gnu.org/software/libc/manual/html_node/Reserved-Names.html):

In addition to the names documented in this manual, reserved names include all external identifiers (global functions and variables) that begin with an underscore (‘_’) and all identifiers regardless of use that begin with either two underscores or an underscore followed by a capital letter are reserved names. This is so that the library and header files can define functions, variables, and macros for internal purposes without risk of conflict with names in user programs.

Closes #454